### PR TITLE
Add additional commands to allow PandA introspection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,4 +13,5 @@
     "editor.codeActionsOnSave": {
         "source.organizeImports": true
     },
+    "files.trimTrailingWhitespace": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "editor.defaultFormatter": "ms-python.python",
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
+    "python.linting.mypyEnabled": true,
     "python.linting.enabled": true,
     "python.testing.pytestArgs": [],
     "python.testing.unittestEnabled": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,4 @@
     "editor.codeActionsOnSave": {
         "source.organizeImports": true
     },
-    "files.trimTrailingWhitespace": true,
-    "files.trimFinalNewlines": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
     "editor.codeActionsOnSave": {
         "source.organizeImports": true
     },
-    "files.trimTrailingWhitespace": true
+    "files.trimTrailingWhitespace": true,
+    "files.trimFinalNewlines": true
 }

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 # Pinning black stops us having to allow pre-releases globally
-black = "==21.5b2"
+black = "==19.10b0"
 
 # Pins to make lockfile usable on multiple Python versions and platforms
 mypy = "*"
@@ -32,3 +32,4 @@ tests = "python -m pytest"
 docs = "sphinx-build -EWT --keep-going docs build/html"
 # Delete any files that git ignore hides from us
 gitclean = "git clean -fdX"
+

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 # Pinning black stops us having to allow pre-releases globally
-black = "==19.10b0"
+black = "==21.7b0"
 
 # Pins to make lockfile usable on multiple Python versions and platforms
 mypy = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ mypy = "*"
 atomicwrites = "*"
 typing-extensions = "*"
 importlib-metadata = "*"
+typed-ast = "*"
 
 # Test and docs dependencies
 pytest-cov = "*"
@@ -26,6 +27,8 @@ sphinx-rtd-theme = "*"
 [packages]
 # All other package requirements from setup.cfg
 pandablocks = {editable = true, extras = ["hdf5"], path = "."}
+# Pins to make lockfile usable on multiple Python versions and platforms
+numpy = "*"
 
 [scripts]
 tests = "python -m pytest"

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 # Pinning black stops us having to allow pre-releases globally
-black = "==19.10b0"
+black = "==21.5b2"
 
 # Pins to make lockfile usable on multiple Python versions and platforms
 mypy = "*"
@@ -32,4 +32,3 @@ tests = "python -m pytest"
 docs = "sphinx-build -EWT --keep-going docs build/html"
 # Delete any files that git ignore hides from us
 gitclean = "git clean -fdX"
-

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ddea8dcf3eb3266c7c60c57f7c9089b8666f95ec0688f52a4cf0fe0811e2ec32"
+            "sha256": "213e1133ca30cc822e88acf2b1366fdddecaea796a428d7fd6f1906684d8abf0"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -139,6 +139,7 @@
                 "sha256:e9459f40244bb02b2f14f6af0cd0732791d72232bbb0dc4bab57ef88e75f6935",
                 "sha256:edb1f041a9146dcf02cd7df7187db46ab524b9af2515f392f337c7cbbf5b52cd"
             ],
+            "index": "pypi",
             "version": "==1.20.2"
         },
         "pandablocks": {
@@ -785,7 +786,7 @@
                 "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
                 "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
             ],
-            "markers": "python_version < '3.8'",
+            "index": "pypi",
             "version": "==1.4.3"
         },
         "typing-extensions": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "774f165c59bde4fe89dc0bf353c2664eeafb258a97b9653869ffc14f3d76692b"
+            "sha256": "ddea8dcf3eb3266c7c60c57f7c9089b8666f95ec0688f52a4cf0fe0811e2ec32"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -247,11 +247,11 @@
         },
         "black": {
             "hashes": [
-                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
-                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+                "sha256:1c7aa6ada8ee864db745b22790a32f94b2795c253a75d6d9b5e439ff10d23116",
+                "sha256:c8373c6491de9362e39271630b65b964607bc5c79c83783547d76c839b3aa219"
             ],
             "index": "pypi",
-            "version": "==19.10b0"
+            "version": "==21.7b0"
         },
         "certifi": {
             "hashes": [
@@ -743,6 +743,14 @@
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
             "version": "==0.10.2"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:056f0376bf5a6b182c513f9582c1e5b0487265eb6c48842b69aa9ca1cd5f640a",
+                "sha256:d60e681734099207a6add7a10326bc2ddd1fdc36c1b0f547d00ef73ac63739c2"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.2.0"
         },
         "typed-ast": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "62852a62579e0583e5ed1270abbbc4c8022bd97a9e6ef18b660496da5aa5de03"
+            "sha256": "774f165c59bde4fe89dc0bf353c2664eeafb258a97b9653869ffc14f3d76692b"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -248,11 +248,11 @@
         },
         "black": {
             "hashes": [
-                "sha256:1fc0e0a2c8ae7d269dfcf0c60a89afa299664f3e811395d40b1922dff8f854b5",
-                "sha256:e5cf21ebdffc7a9b29d73912b6a6a9a4df4ce70220d523c21647da2eae0751ef"
+                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
+                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
             ],
             "index": "pypi",
-            "version": "==21.5b2"
+            "version": "==19.10b0"
         },
         "certifi": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -139,7 +139,6 @@
                 "sha256:e9459f40244bb02b2f14f6af0cd0732791d72232bbb0dc4bab57ef88e75f6935",
                 "sha256:edb1f041a9146dcf02cd7df7187db46ab524b9af2515f392f337c7cbbf5b52cd"
             ],
-            "markers": "python_version == '3.7'",
             "version": "==1.20.2"
         },
         "pandablocks": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "774f165c59bde4fe89dc0bf353c2664eeafb258a97b9653869ffc14f3d76692b"
+            "sha256": "62852a62579e0583e5ed1270abbbc4c8022bd97a9e6ef18b660496da5aa5de03"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -139,6 +139,7 @@
                 "sha256:e9459f40244bb02b2f14f6af0cd0732791d72232bbb0dc4bab57ef88e75f6935",
                 "sha256:edb1f041a9146dcf02cd7df7187db46ab524b9af2515f392f337c7cbbf5b52cd"
             ],
+            "markers": "python_version == '3.7'",
             "version": "==1.20.2"
         },
         "pandablocks": {
@@ -233,10 +234,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
-                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
-            "version": "==20.3.0"
+            "version": "==21.2.0"
         },
         "babel": {
             "hashes": [
@@ -247,11 +248,11 @@
         },
         "black": {
             "hashes": [
-                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
-                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+                "sha256:1fc0e0a2c8ae7d269dfcf0c60a89afa299664f3e811395d40b1922dff8f854b5",
+                "sha256:e5cf21ebdffc7a9b29d73912b6a6a9a4df4ce70220d523c21647da2eae0751ef"
             ],
             "index": "pypi",
-            "version": "==19.10b0"
+            "version": "==21.5b2"
         },
         "certifi": {
             "hashes": [

--- a/docs/explanations/sans-io.rst
+++ b/docs/explanations/sans-io.rst
@@ -30,7 +30,7 @@ corresponding `ControlConnection` and `DataConnection` objects:
     bytes that should be send back. The :meth:`~ControlConnection.responses`
     method returns an iterator of ``(command, response)`` tuples that have now
     completed. The response type will depend on the command. For instance `Get`
-    returns `bytes` or a `list` of `bytes` of the field value, and `GetFields`
+    returns `bytes` or a `list` of `bytes` of the field value, and `GetFieldInfo`
     returns a `dict` mapping `str` field name to `FieldInfo`.
 
 .. autoclass:: DataConnection

--- a/docs/explanations/sans-io.rst
+++ b/docs/explanations/sans-io.rst
@@ -31,7 +31,7 @@ corresponding `ControlConnection` and `DataConnection` objects:
     method returns an iterator of ``(command, response)`` tuples that have now
     completed. The response type will depend on the command. For instance `Get`
     returns `bytes` or a `list` of `bytes` of the field value, and `GetFields`
-    returns a `dict` mapping `str` field name to `FieldType`.
+    returns a `dict` mapping `str` field name to `FieldInfo`.
 
 .. autoclass:: DataConnection
     :noindex:

--- a/docs/how-to/introspect-panda.rst
+++ b/docs/how-to/introspect-panda.rst
@@ -1,0 +1,22 @@
+How to introspect a PandA
+===========================
+
+Using a combination of `commands <pandablocks.commands>` it is straightforward to query the PandA
+to list all blocks, and all fields inside each block, that exist. 
+
+Call the following script, with the address of the PandA as the first and only command line argument:
+
+
+.. literalinclude:: ../../examples/introspect_panda.py
+
+This script can be found in ``docs/examples/introspect_panda.py``.
+
+By examining the `BlockInfo` structure returned from `GetBlockInfo` for each Block the number
+and description may be acquired for every block.
+
+By examining the `FieldInfo` structure (which is fully printed in this example) the ``type``, 
+``sub-type``, ``description`` and ``label`` may all be found for every field. 
+
+Lastly the complete list of every ``BITS`` field in the ``PCAP`` block are gathered and
+printed. See the documentation in the `Field Types <https://pandablocks-server.readthedocs.io/en/latest/fields.html?#field-types>`_
+section of the PandA Server documentation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ Practical step-by-step guides for the more experienced user.
 
     how-to/library-hdf
     how-to/poll-changes
+    how-to/introspect-panda
 
 .. rst-class:: columns
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -23,7 +23,7 @@ from code:
     There is a `Command` subclass for every sort of command that can be sent to
     the `ControlConnection` of a PandA. Many common actions can be accomplished
     with a simple `Get` or `Put`, but some convenience commands like
-    `GetBlockNumbers`, `GetFields`, etc. are provided that parse output into
+    `GetBlockInfo`, `GetFields`, etc. are provided that parse output into
     specific classes.
 
 
@@ -82,4 +82,3 @@ from code:
     gives multi-CPU benefits without hitting the limit of the GIL.
 
     .. seealso:: `library-hdf`, `performance`
-

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -23,7 +23,7 @@ from code:
     There is a `Command` subclass for every sort of command that can be sent to
     the `ControlConnection` of a PandA. Many common actions can be accomplished
     with a simple `Get` or `Put`, but some convenience commands like
-    `GetBlockInfo`, `GetFields`, etc. are provided that parse output into
+    `GetBlockInfo`, `GetFieldInfo`, etc. are provided that parse output into
     specific classes.
 
 

--- a/examples/introspect_panda.py
+++ b/examples/introspect_panda.py
@@ -3,7 +3,7 @@ import pprint
 import sys
 
 from pandablocks.asyncio import AsyncioClient
-from pandablocks.commands import GetBlockInfo, GetPcapBitsLabels
+from pandablocks.commands import GetBlockInfo, GetFieldInfo, GetPcapBitsLabels
 
 
 # TODO: Add this to documentation somewhere!
@@ -16,6 +16,9 @@ async def introspect():
 
         block_info = await client.send(GetBlockInfo())
         pprint.pprint(block_info)
+
+        field_info = await client.send(GetFieldInfo("LUT"))
+        pprint.pprint(field_info)
 
 
 if __name__ == "__main__":

--- a/examples/introspect_panda.py
+++ b/examples/introspect_panda.py
@@ -6,7 +6,6 @@ from pandablocks.asyncio import AsyncioClient
 from pandablocks.commands import GetBlockInfo, GetFieldInfo, GetPcapBitsLabels
 
 
-# TODO: Add this to documentation somewhere!
 async def introspect():
     # Create a client and connect the control and data ports
     async with AsyncioClient(sys.argv[1]) as client:
@@ -18,7 +17,7 @@ async def introspect():
             field_info = await client.send(GetFieldInfo(block))
             pprint.pprint({block: field_info})
 
-        # Get the labels for the PCAP.BITS* fields
+        # Get the labels for every PCAP.BITS[n] fields
         labels = await client.send(GetPcapBitsLabels())
         pprint.pprint(labels)
 

--- a/examples/introspect_panda.py
+++ b/examples/introspect_panda.py
@@ -11,14 +11,16 @@ async def introspect():
     # Create a client and connect the control and data ports
     async with AsyncioClient(sys.argv[1]) as client:
 
+        # Get the list of all blocks in the PandA
+        block_info = await client.send(GetBlockInfo())
+        # Find and print all fields for each block
+        for block in block_info:
+            field_info = await client.send(GetFieldInfo(block))
+            pprint.pprint({block: field_info})
+
+        # Get the labels for the PCAP.BITS* fields
         labels = await client.send(GetPcapBitsLabels())
         pprint.pprint(labels)
-
-        block_info = await client.send(GetBlockInfo())
-        pprint.pprint(block_info)
-
-        field_info = await client.send(GetFieldInfo("LUT"))
-        pprint.pprint(field_info)
 
 
 if __name__ == "__main__":

--- a/examples/introspect_panda.py
+++ b/examples/introspect_panda.py
@@ -1,0 +1,20 @@
+import asyncio
+import pprint
+import sys
+
+from pandablocks.asyncio import AsyncioClient
+from pandablocks.commands import GetPcapBitsLabels
+
+
+# TODO: Add this to documentation somewhere!
+async def introspect():
+    # Create a client and connect the control and data ports
+    async with AsyncioClient(sys.argv[1]) as client:
+
+        labels = await client.send(GetPcapBitsLabels())
+        pprint.pprint(labels)
+
+
+if __name__ == "__main__":
+    # One-shot run of a co-routine
+    asyncio.run(introspect())

--- a/examples/introspect_panda.py
+++ b/examples/introspect_panda.py
@@ -3,7 +3,7 @@ import pprint
 import sys
 
 from pandablocks.asyncio import AsyncioClient
-from pandablocks.commands import GetPcapBitsLabels
+from pandablocks.commands import GetBlockInfo, GetPcapBitsLabels
 
 
 # TODO: Add this to documentation somewhere!
@@ -13,6 +13,9 @@ async def introspect():
 
         labels = await client.send(GetPcapBitsLabels())
         pprint.pprint(labels)
+
+        block_info = await client.send(GetBlockInfo())
+        pprint.pprint(block_info)
 
 
 if __name__ == "__main__":

--- a/pandablocks/_control.py
+++ b/pandablocks/_control.py
@@ -2,7 +2,7 @@ from string import digits
 from typing import Dict, List, Optional
 
 from .blocking import BlockingClient
-from .commands import FieldType, GetBlockNumbers, GetFields, Raw, is_multiline_command
+from .commands import FieldType, GetBlockInfo, GetFields, Raw, is_multiline_command
 
 
 def _get_user_input(prompt) -> List[str]:
@@ -38,7 +38,7 @@ class BlockCompleter:
     def __init__(self, client: BlockingClient):
         self.matches: List[str] = []
         self._client = client
-        self._blocks = self._client.send(GetBlockNumbers(), timeout=2)
+        self._blocks = self._client.send(GetBlockInfo(), timeout=2)
         self._fields = self._get_fields(list(self._blocks))
 
     def _get_fields(self, blocks: List[str]) -> Dict[str, Dict[str, FieldType]]:
@@ -46,7 +46,8 @@ class BlockCompleter:
         return dict(zip(blocks, fields))
 
     def _with_suffixes(self, block: str, numbers: bool) -> List[str]:
-        num = self._blocks[block]
+        block_info = self._blocks[block]
+        num = block_info.number
         if numbers and num > 1:
             return [f"{block}{i}" for i in range(1, num + 1)]
         else:

--- a/pandablocks/_control.py
+++ b/pandablocks/_control.py
@@ -38,12 +38,15 @@ class BlockCompleter:
     def __init__(self, client: BlockingClient):
         self.matches: List[str] = []
         self._client = client
-        self._blocks = self._client.send(GetBlockInfo(), timeout=2)
+        self._blocks = self._client.send(GetBlockInfo(True), timeout=2)
         self._fields = self._get_fields(list(self._blocks))
-        # TODO: Extend use of _fields now we have more info available?
+        # TODO: Extend use of _fields now we have enum labels available?
 
     def _get_fields(self, blocks: List[str]) -> Dict[str, Dict[str, FieldInfo]]:
-        fields = self._client.send([GetFieldInfo(block) for block in blocks], timeout=2)
+        fields = self._client.send(
+            [GetFieldInfo(block, True) for block in blocks],
+            timeout=2,
+        )
         return dict(zip(blocks, fields))
 
     def _with_suffixes(self, block: str, numbers: bool) -> List[str]:

--- a/pandablocks/_control.py
+++ b/pandablocks/_control.py
@@ -2,7 +2,7 @@ from string import digits
 from typing import Dict, List, Optional
 
 from .blocking import BlockingClient
-from .commands import FieldType, GetBlockInfo, GetFields, Raw, is_multiline_command
+from .commands import FieldInfo, GetBlockInfo, GetFieldInfo, Raw, is_multiline_command
 
 
 def _get_user_input(prompt) -> List[str]:
@@ -40,9 +40,10 @@ class BlockCompleter:
         self._client = client
         self._blocks = self._client.send(GetBlockInfo(), timeout=2)
         self._fields = self._get_fields(list(self._blocks))
+        # TODO: Extend use of _fields now we have more info available?
 
-    def _get_fields(self, blocks: List[str]) -> Dict[str, Dict[str, FieldType]]:
-        fields = self._client.send([GetFields(block) for block in blocks], timeout=2)
+    def _get_fields(self, blocks: List[str]) -> Dict[str, Dict[str, FieldInfo]]:
+        fields = self._client.send([GetFieldInfo(block) for block in blocks], timeout=2)
         return dict(zip(blocks, fields))
 
     def _with_suffixes(self, block: str, numbers: bool) -> List[str]:

--- a/pandablocks/blocking.py
+++ b/pandablocks/blocking.py
@@ -97,9 +97,13 @@ class BlockingClient:
             to_send = self._ctrl_connection.receive_bytes(received)
             s.sendall(to_send)
             responses += list(self._ctrl_connection.responses())
-        assert all(
-            c == r[0] for c, r in zip(commands, responses)
-        ), f"Mismatched {commands} and {responses}"
+        # assert all(
+        #     c == r[0] for c, r in zip(commands, responses)
+        # ), f"Mismatched {commands} and {responses}"
+
+        for c, r in zip(commands, responses):
+            assert c == r[0], f"Mismatched {c} and {r}"
+
         for _, response in responses:
             if isinstance(response, Exception):
                 raise response

--- a/pandablocks/blocking.py
+++ b/pandablocks/blocking.py
@@ -1,5 +1,5 @@
 import socket
-from typing import Any, Iterable, Iterator, List, Optional, Tuple, Union, overload
+from typing import Iterable, Iterator, List, Optional, Union, overload
 
 from .commands import Command, T
 from .connections import ControlConnection, DataConnection
@@ -91,26 +91,23 @@ class BlockingClient:
         for command in commands:
             to_send = self._ctrl_connection.send(command)
             s.sendall(to_send)
-        responses: List[Tuple[Command, Any]] = []
-        while len(responses) < len(commands):
+        # Rely on dicts being ordered, Ellipsis is shorthand for "no response yet"
+        cr = {id(command): ... for command in commands}
+        while ... in cr.values():
             received = s.recv(4096)
             to_send = self._ctrl_connection.receive_bytes(received)
             s.sendall(to_send)
-            responses += list(self._ctrl_connection.responses())
-        # assert all(
-        #     c == r[0] for c, r in zip(commands, responses)
-        # ), f"Mismatched {commands} and {responses}"
-
-        for c, r in zip(commands, responses):
-            assert c == r[0], f"Mismatched {c} and {r}"
-
-        for _, response in responses:
+            for command, response in self._ctrl_connection.responses():
+                assert cr[id(command)] is ..., "Already got response for {command}"
+                cr[id(command)] = response
+        responses = list(cr.values())
+        for response in responses:
             if isinstance(response, Exception):
                 raise response
         if len(responses) == 1:
-            return responses[0][1]
+            return responses[0]
         else:
-            return [r[1] for r in responses]
+            return responses
 
     def data(self, scaled: bool = True, frame_timeout: int = None) -> Iterator[Data]:
         """Connect to data port and yield data frames

--- a/pandablocks/cli.py
+++ b/pandablocks/cli.py
@@ -50,7 +50,10 @@ def cli(ctx, log_level: str):
 
 @cli.command()
 @click.option(
-    "--num", help="Number of collections to capture", default=1, show_default=True,
+    "--num",
+    help="Number of collections to capture",
+    default=1,
+    show_default=True,
 )
 @click.option(
     "--arm",
@@ -83,7 +86,9 @@ def hdf(host: str, scheme: str, num: int, arm: bool):
 @cli.command()
 @click.option("--prompt", help="Prompt character", default=PROMPT, show_default=True)
 @click.option(
-    "--no-readline", help="Disable readline history and completion", is_flag=True,
+    "--no-readline",
+    help="Disable readline history and completion",
+    is_flag=True,
 )
 @click.argument("host", type=str)
 def control(host: str, prompt: str, no_readline: bool):

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -180,7 +180,7 @@ class Get(Command[Union[str, List[str]]]):
         else:
             # We got OK =value
             line = ex.line
-            assert line.startswith("OK ="), f"'{line}' does not start with 'OK ='"
+            assert line.startswith("OK =")
             return line[4:]
 
 

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 from ._exchange import Exchange, ExchangeGenerator
-from .responses import Changes, FieldInfo
+from .responses import BlockInfo, Changes, FieldInfo
 
 # Define the public API of this module
 __all__ = [
@@ -240,12 +240,6 @@ class Disarm(Command[None]):
         assert ex.line == "OK"
 
 
-@dataclass
-class BlockInfo:
-    number: int = 0
-    description: str = ""
-
-
 class GetBlockInfo(Command[Dict[str, BlockInfo]]):
     """Get the name, number, and description of each block type
     in a dictionary, alphabetically ordered
@@ -295,7 +289,7 @@ class GetFieldInfo(Command[Dict[str, FieldInfo]]):
                 FieldInfo(type='bit_mux',
                         subtype=None,
                         description='Input A',
-                        label=['TTLIN1.VAL', 'TTLIN2.VAL' ...]),
+                        label=['TTLIN1.VAL', 'TTLIN2.VAL', ...]),
             ...}
     """
 

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -2,17 +2,7 @@ import logging
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import (
-    Any,
-    Dict,
-    Generic,
-    List,
-    OrderedDict,
-    Tuple,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Dict, Generic, List, Tuple, TypeVar, Union, overload
 
 from ._exchange import Exchange, ExchangeGenerator
 from .responses import BlockInfo, Changes, FieldInfo
@@ -102,8 +92,8 @@ def _execute_commands(*commands: Command[Any]) -> ExchangeGenerator[Tuple[Any, .
 
 def _execute_commands(*commands):
     """Call the `Command.execute` method on each of the commands to produce
-    some `Exchange` generators. , then
-    zip together the  to produce a"""
+    some `Exchange` generators, which are yielded back to the connection,
+    then zip together the responses to those exchanges into a tuple"""
     # If we add type annotations to this function then mypy complains:
     # Overloaded function implementation does not accept all possible arguments
     # As we want to type check this, we put the logic in _zip_with_return
@@ -190,7 +180,7 @@ class Get(Command[Union[str, List[str]]]):
         else:
             # We got OK =value
             line = ex.line
-            assert line.startswith("OK ="), f"{line} does not start with 'OK ='"
+            assert line.startswith("OK ="), f"'{line}' does not start with 'OK ='"
             return line[4:]
 
 
@@ -271,7 +261,8 @@ class GetBlockInfo(Command[Dict[str, BlockInfo]]):
             commands.append(Get(f"*DESC.{block}"))
 
         if self.skip_description:
-            description_values = [None for _ in commands]
+            # Must use tuple() to match type returned by _execute_commands
+            description_values = tuple(None for _ in commands)
         else:
             description_values = yield from _execute_commands(*commands)
 

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -294,7 +294,7 @@ class GetPcapBitsLabels(Command):
     """
 
     def execute(self) -> ExchangeGenerator[Dict[str, List[str]]]:
-        ex = Exchange("PCAP.*?\n")
+        ex = Exchange("PCAP.*?")
         yield ex
         bits_fields = []
         for line in ex.multiline:
@@ -304,11 +304,10 @@ class GetPcapBitsLabels(Command):
                 if field_type == "ext_out" and field_subtype == "bits":
                     bits_fields.append("PCAP.%s" % field_name)
 
-        result = map(lambda field: field + ".BITS?\n", bits_fields)
-        ex = Exchange(list(result))
-        yield ex
-        for line in ex.multiline:
-            pass  # todo
+        exchanges = [Exchange(f"{field}.BITS?") for field in bits_fields)]
+        yield exchanges
+        bits = {field: ex.multiline for field, ex in zip(bits_fields, exchanges)}
+        return bits
 
 
 class ChangeGroup(Enum):

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -280,7 +280,7 @@ class GetPcapBitsLabels(Command):
 
     For example::
 
-        GetPcapBitsLabels() -> PcapBitsLabels()
+        GetPcapBitsLabels() -> {"BITS0" : ["TTLIN1.VAL", "TTLIN2.VAL", ...], ...}
     """
 
     def execute(self) -> ExchangeGenerator[Dict[str, List[str]]]:

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -301,20 +301,15 @@ class GetFieldInfo(Command[Dict[str, FieldInfo]]):
         unsorted: Dict[int, Tuple[str, FieldInfo]] = {}
         for line in ex.multiline:
             name, index, type_subtype = line.split(maxsplit=2)
-            # Awkward unpacking of the variable-length "type_subtype" variable, instead
-            # of "*type_subtype.split()", to avoid mypy error:
-            # 'Argument 1 to "FieldInfo" has incompatible type "*List[str]";
-            # expected "Optional[List[str]]" '
+
             field_type: str
             subtype: Optional[str]
-            if " " in type_subtype:
-                # We have both a type and sub-type
-                field_type, subtype = type_subtype.split(maxsplit=1)
-            else:
-                field_type = type_subtype
-                subtype = None
+            # Append "None" to list below so there are always at least 2 elements
+            # so we can always unpack into subtype, even if no split occurs.
+            field_type, subtype, *_ = [*type_subtype.split(maxsplit=1), None]
 
             unsorted[int(index)] = (name, FieldInfo(field_type, subtype))
+
         # Dict keeps insertion order, so insert in the order the server said
         fields = {name: field for _, (name, field) in sorted(unsorted.items())}
 

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -286,7 +286,7 @@ class GetBlockInfo(Command[Dict[str, BlockInfo]]):
 @dataclass
 class GetFieldInfo(Command[Dict[str, FieldInfo]]):
     """Get the fields of a block, returning a `FieldInfo` for each one, ordered
-    to match the definition order in the PandA #TODO: Confirm order of variables!
+    to match the definition order in the PandA
 
     Args:
         block: The name of the block type

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -299,11 +299,11 @@ class GetFieldInfo(Command[Dict[str, FieldInfo]]):
         yield ex
         unsorted: Dict[int, Tuple[str, FieldInfo]] = {}
         for line in ex.multiline:
-            # Append "None" to list below as there isn't always a subtype in line,
-            # so the .split() will sometimes only produce 3 elements. If there is a
-            # subtype in line, *_ will swallow the trailing None.
-            name, index, field_type, subtype, *_ = [*line.split(maxsplit=3), None]
+            name, index, type_subtype = line.split(maxsplit=2)
 
+            # Append "None" to list below so there are always at least 2 elements
+            # so we can always unpack into subtype, even if no split occurs.
+            field_type, subtype, *_ = [*type_subtype.split(maxsplit=1), None]
             unsorted[int(index)] = (name, FieldInfo(field_type, subtype))
 
         # Dict keeps insertion order, so insert in the order the server said
@@ -339,7 +339,7 @@ class GetFieldInfo(Command[Dict[str, FieldInfo]]):
             if command.field.startswith("*DESC"):
                 field_info.description = value
             elif command.field.startswith("*ENUMS"):
-                field_info.label = value
+                field_info.labels = value
 
         return fields
 

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -319,15 +319,14 @@ class GetFieldInfo(Command[Dict[str, FieldInfo]]):
             commands.append(Get(f"*DESC.{self.block}.{field}"))
             field_mapping[len(commands) - 1] = field
 
-            # TODO: enum'ize these strings?
             if (
                 field_info.type in ("bit_mux", "pos_mux", "ext_out")
                 or field_info.subtype == "enum"
             ):
-                get_str = f"*ENUMS.{self.block}.{field}"
+                enum_str = f"*ENUMS.{self.block}.{field}"
                 if field_info.type == "ext_out":
-                    get_str += ".CAPTURE"
-                commands.append(Get(get_str))
+                    enum_str += ".CAPTURE"
+                commands.append(Get(enum_str))
                 field_mapping[len(commands) - 1] = field
 
         returned_values = yield from _execute_commands(*commands)
@@ -336,7 +335,7 @@ class GetFieldInfo(Command[Dict[str, FieldInfo]]):
         for idx, value in enumerate(returned_values):
             command: Get = commands[idx]
             field_info = fields[field_mapping[idx]]
-            # TODO: Confirm that there's no way we'll get misaligned index accessing
+
             if command.field.startswith("*DESC"):
                 field_info.description = value
             elif command.field.startswith("*ENUMS"):
@@ -361,9 +360,9 @@ class GetPcapBitsLabels(Command):
             split = line.split()
             if len(split) == 4:
                 field_name, _, field_type, field_subtype = split
-                # TODO: enum'ize these strings?
+
                 if field_type == "ext_out" and field_subtype == "bits":
-                    bits_fields.append("PCAP.%s" % field_name)
+                    bits_fields.append(f"PCAP.{field_name}")
 
         exchanges = [Exchange(f"{field}.BITS?") for field in bits_fields]
         yield exchanges

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -7,7 +7,6 @@ from typing import (
     Dict,
     Generic,
     List,
-    Optional,
     OrderedDict,
     Tuple,
     TypeVar,
@@ -300,13 +299,10 @@ class GetFieldInfo(Command[Dict[str, FieldInfo]]):
         yield ex
         unsorted: Dict[int, Tuple[str, FieldInfo]] = {}
         for line in ex.multiline:
-            name, index, type_subtype = line.split(maxsplit=2)
-
-            field_type: str
-            subtype: Optional[str]
-            # Append "None" to list below so there are always at least 2 elements
-            # so we can always unpack into subtype, even if no split occurs.
-            field_type, subtype, *_ = [*type_subtype.split(maxsplit=1), None]
+            # Append "None" to list below as there isn't always a subtype in line,
+            # so the .split() will sometimes only produce 3 elements. If there is a
+            # subtype in line, *_ will swallow the trailing None.
+            name, index, field_type, subtype, *_ = [*line.split(maxsplit=3), None]
 
             unsorted[int(index)] = (name, FieldInfo(field_type, subtype))
 

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -190,7 +190,7 @@ class Get(Command[Union[str, List[str]]]):
         else:
             # We got OK =value
             line = ex.line
-            assert line.startswith("OK ="), "Line did not start with 'OK ='"
+            assert line.startswith("OK ="), f"{line} does not start with 'OK ='"
             return line[4:]
 
 
@@ -271,16 +271,16 @@ class GetBlockInfo(Command[Dict[str, BlockInfo]]):
             commands.append(Get(f"*DESC.{block}"))
 
         if self.skip_description:
-            description_values = tuple(None for _ in range(len(commands)))
+            description_values = [None for _ in commands]
         else:
             description_values = yield from _execute_commands(*commands)
 
-        blocks_info = {
-            block[0]: BlockInfo(number=block[1], description=desc)
-            for block, desc in zip(blocks_list, description_values)
+        block_infos = {
+            block: BlockInfo(number=num, description=desc)
+            for (block, num), desc in sorted(zip(blocks_list, description_values))
         }
 
-        return OrderedDict(sorted(blocks_info.items()))
+        return block_infos
 
 
 @dataclass

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -2,17 +2,7 @@ import logging
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import (
-    Any,
-    Dict,
-    Generic,
-    List,
-    OrderedDict,
-    Tuple,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Dict, Generic, List, Tuple, TypeVar, Union, overload
 
 from ._exchange import Exchange, ExchangeGenerator
 from .responses import Changes, FieldType
@@ -304,7 +294,7 @@ class GetPcapBitsLabels(Command):
                 if field_type == "ext_out" and field_subtype == "bits":
                     bits_fields.append("PCAP.%s" % field_name)
 
-        exchanges = [Exchange(f"{field}.BITS?") for field in bits_fields)]
+        exchanges = [Exchange(f"{field}.BITS?") for field in bits_fields]
         yield exchanges
         bits = {field: ex.multiline for field, ex in zip(bits_fields, exchanges)}
         return bits

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -290,13 +290,13 @@ class GetFieldInfo(Command[Dict[str, FieldInfo]]):
 
     For example::
 
-    GetFieldInfo("LUT") -> {
-        "INPA":
-            FieldInfo(type='bit_mux',
-                      subtype=None,
-                      description='Input A',
-                      label=['TTLIN1.VAL', 'TTLIN2.VAL' ...]),
-        ...}
+        GetFieldInfo("LUT") -> {
+            "INPA":
+                FieldInfo(type='bit_mux',
+                        subtype=None,
+                        description='Input A',
+                        label=['TTLIN1.VAL', 'TTLIN2.VAL' ...]),
+            ...}
     """
 
     block: str
@@ -347,7 +347,7 @@ class GetFieldInfo(Command[Dict[str, FieldInfo]]):
 
         returned_values = yield from _execute_commands(*commands)
 
-        # Merge the returned information back into the existing fields dictionary
+        # Merge the returned information back into the existing FieldInfo for each field
         for idx, value in enumerate(returned_values):
             command: Get = commands[idx]
             field_info = fields[field_mapping[idx]]

--- a/pandablocks/connections.py
+++ b/pandablocks/connections.py
@@ -22,6 +22,7 @@ from .responses import (
 # Define the public API of this module
 __all__ = [
     "NeedMoreData",
+    "NoContextAvailable",
     "Buffer",
     "ControlConnection",
     "DataConnection",
@@ -33,6 +34,12 @@ SAMPLES_FIELD = "PCAP.SAMPLES.Value"
 
 class NeedMoreData(Exception):
     """Raised if the `Buffer` isn't full enough to return the requested bytes"""
+
+
+class NoContextAvailable(Exception):
+    """Raised if there were no contexts available for this connection.
+    This may result from calling `ControlConnection.receive_bytes()` without calling
+    `ControlConnection.send()` """
 
 
 class Buffer:
@@ -149,6 +156,8 @@ class ControlConnection:
 
     def _update_contexts(self, lines: List[str], is_multiline=False) -> bytes:
         to_send = b""
+        if len(self._contexts) == 0:
+            raise NoContextAvailable()
         context = self._contexts.popleft()
         # Update the exchange with what we've got
         context.exchange.received = lines

--- a/pandablocks/connections.py
+++ b/pandablocks/connections.py
@@ -177,6 +177,10 @@ class ControlConnection:
     ) -> Iterator[bytes]:
         if not isinstance(exchanges, list):
             exchanges = [exchanges]
+        # No Exchanges when a Command's yield is empty e.g. unexpected/unparseable data
+        # received from PandA
+        if len(exchanges) == 0:
+            return ""
         for ex in exchanges:
             context = _ExchangeContext(ex, command)
             self._contexts.append(context)

--- a/pandablocks/connections.py
+++ b/pandablocks/connections.py
@@ -39,7 +39,7 @@ class NeedMoreData(Exception):
 class NoContextAvailable(Exception):
     """Raised if there were no contexts available for this connection.
     This may result from calling `ControlConnection.receive_bytes()` without calling
-    `ControlConnection.send()` """
+    `ControlConnection.send()`, or if there were unmatched sends/receives """
 
 
 class Buffer:

--- a/pandablocks/connections.py
+++ b/pandablocks/connections.py
@@ -39,7 +39,7 @@ class NeedMoreData(Exception):
 class NoContextAvailable(Exception):
     """Raised if there were no contexts available for this connection.
     This may result from calling `ControlConnection.receive_bytes()` without calling
-    `ControlConnection.send()`, or if there were unmatched sends/receives """
+    `ControlConnection.send()`, or if there were unmatched sends/receives"""
 
 
 class Buffer:
@@ -321,7 +321,8 @@ class DataConnection:
                 # sent
                 name, capture = SAMPLES_FIELD.rsplit(".", maxsplit=1)
                 fields.insert(
-                    0, FieldCapture(name, np.dtype("uint32"), capture),
+                    0,
+                    FieldCapture(name, np.dtype("uint32"), capture),
                 )
             self._frame_dtype = np.dtype(
                 [(f"{f.name}.{f.capture}", f.type) for f in fields]

--- a/pandablocks/connections.py
+++ b/pandablocks/connections.py
@@ -189,7 +189,7 @@ class ControlConnection:
         # No Exchanges when a Command's yield is empty e.g. unexpected/unparseable data
         # received from PandA
         if len(exchanges) == 0:
-            return ""
+            return
         for ex in exchanges:
             context = _ExchangeContext(ex, command)
             self._contexts.append(context)

--- a/pandablocks/hdf.py
+++ b/pandablocks/hdf.py
@@ -86,7 +86,10 @@ class HDFWriter(Pipeline):
             # No processor, datatype passed through
             dtype = field.type
         return self.hdf_file.create_dataset(
-            f"/{field.name}.{field.capture}", dtype=dtype, shape=(0,), maxshape=(None,),
+            f"/{field.name}.{field.capture}",
+            dtype=dtype,
+            shape=(0,),
+            maxshape=(None,),
         )
 
     def open_file(self, data: StartData):

--- a/pandablocks/responses.py
+++ b/pandablocks/responses.py
@@ -30,7 +30,7 @@ class BlockInfo:
         description: The description for this block"""
 
     number: int = 0
-    description: str = ""
+    description: Optional[str] = None
 
 
 @dataclass

--- a/pandablocks/responses.py
+++ b/pandablocks/responses.py
@@ -6,6 +6,7 @@ import numpy as np
 
 # Define the public API of this module
 __all__ = [
+    "BlockInfo",
     "FieldInfo",
     "Changes",
     "EndReason",
@@ -18,6 +19,18 @@ __all__ = [
 ]
 
 # Control
+
+
+@dataclass
+class BlockInfo:
+    """Block number and description as exposed by the TCP server
+
+    Attributes:
+        number: The index of this block
+        description: The description for this block"""
+
+    number: int = 0
+    description: str = ""
 
 
 @dataclass

--- a/pandablocks/responses.py
+++ b/pandablocks/responses.py
@@ -6,7 +6,7 @@ import numpy as np
 
 # Define the public API of this module
 __all__ = [
-    "FieldType",
+    "FieldInfo",
     "Changes",
     "EndReason",
     "FieldCapture",
@@ -21,17 +21,22 @@ __all__ = [
 
 
 @dataclass
-class FieldType:
-    """Field type and subtype as exposed by TCP server:
+class FieldInfo:
+    """Field type, subtype, description and label as exposed by TCP server:
     https://pandablocks-server.readthedocs.io/en/latest/fields.html#field-types
 
     Attributes:
         type: Field type, like "param", "bit_out", "pos_mux", etc.
         subtype: Some types have subtype, like "uint", "scalar", "lut", etc.
+        description: A description of the field
+        label: A list of the valid values for the field when there is a defined list
+        of valid values, e.g. those with sub-type "enum"
     """
 
     type: str
     subtype: Optional[str] = None
+    description: Optional[str] = None
+    label: Optional[List[str]] = None
 
 
 @dataclass
@@ -125,7 +130,7 @@ class FrameData(Data):
         data: A numpy `Structured Array <structured_arrays>`
 
     Data is structured into complete columns. Each column name is
-    ``<name>.<capture>`` from the corresponding `FieldType`. Data
+    ``<name>.<capture>`` from the corresponding `FieldInfo`. Data
     can be accessed with these column names. For example::
 
         # Table view with 2 captured fields

--- a/pandablocks/responses.py
+++ b/pandablocks/responses.py
@@ -35,21 +35,21 @@ class BlockInfo:
 
 @dataclass
 class FieldInfo:
-    """Field type, subtype, description and label as exposed by TCP server:
+    """Field type, subtype, description and labels as exposed by TCP server:
     https://pandablocks-server.readthedocs.io/en/latest/fields.html#field-types
 
     Attributes:
         type: Field type, like "param", "bit_out", "pos_mux", etc.
         subtype: Some types have subtype, like "uint", "scalar", "lut", etc.
         description: A description of the field
-        label: A list of the valid values for the field when there is a defined list
+        labels: A list of the valid values for the field when there is a defined list
             of valid values, e.g. those with sub-type "enum"
     """
 
     type: str
     subtype: Optional[str] = None
     description: Optional[str] = None
-    label: Optional[List[str]] = None
+    labels: Optional[List[str]] = None
 
 
 @dataclass

--- a/pandablocks/responses.py
+++ b/pandablocks/responses.py
@@ -30,7 +30,7 @@ class FieldInfo:
         subtype: Some types have subtype, like "uint", "scalar", "lut", etc.
         description: A description of the field
         label: A list of the valid values for the field when there is a defined list
-        of valid values, e.g. those with sub-type "enum"
+            of valid values, e.g. those with sub-type "enum"
     """
 
     type: str

--- a/tests/test_blocking.py
+++ b/tests/test_blocking.py
@@ -22,7 +22,9 @@ def test_blocking_bad_put_raises(dummy_server_in_thread):
 
 
 def test_blocking_data(
-    dummy_server_in_thread, slow_dump, slow_dump_expected,
+    dummy_server_in_thread,
+    slow_dump,
+    slow_dump_expected,
 ):
     dummy_server_in_thread.data = slow_dump
     events = []

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -12,8 +12,14 @@ def dummy_server_with_blocks(dummy_server_in_thread):
         # TODO: Ask why no \n or '.' at end of above line
         "!INPB 1 bit_mux\n!TYPEA 5 param enum\n.",  # LUT fields
         "!TRIG_EDGE 3 param enum\n!GATE 1 bit_mux\n.",  # PCAP fields
-        "OK =LUT INPB Desc\n!TTLIN1.VAL\n!LVDSIN1.VAL\n.\nOK =LUT TYPEA Desc\n!Input-Level\n!Pulse-On-Rising-Edge\n.\nOK =PCAP GATE Desc\n!TTLIN1.VAL\n!LVDSIN1.VAL\n.\nOK =PCAP TRIG_EDGE Desc\n!Rising\n!Falling\n.",
+        # Next 4 lines deliberately concatenated so they are sent as one long response
+        "OK =LUT INPB Desc\n!TTLIN1.VAL\n!LVDSIN1.VAL\n.\n"
+        "OK =LUT TYPEA Desc\n!Input-Level\n!Pulse-On-Rising-Edge\n.\n"
+        "OK =PCAP GATE Desc\n!TTLIN1.VAL\n!LVDSIN1.VAL\n.\n"
+        "OK =PCAP TRIG_EDGE Desc\n!Rising\n!Falling\n.",
     ]
+    # TODO: Ask about DummyServer throwing an exception during these tests -is it still a failure
+    # if that testware server throws exceptions?
     yield dummy_server_in_thread
 
 
@@ -48,7 +54,7 @@ def test_complete_stars(dummy_server_with_blocks):
         ]
         assert completer("*DE", 0) == "*DESC.LUT"
         assert completer.matches == ["*DESC.LUT", "*DESC.PCAP"]
-        assert completer("*DESC.LUT.", 0) == "*DESC.LUT.TYPEA_INP"
-        assert completer.matches == ["*DESC.LUT.TYPEA_INP", "*DESC.LUT.TYPEA"]
+        assert completer("*DESC.LUT.", 0) == "*DESC.LUT.INPB"
+        assert completer.matches == ["*DESC.LUT.INPB", "*DESC.LUT.TYPEA"]
         assert completer("*ENUMS.LU", 0) == "*ENUMS.LUT"
         assert completer.matches == ["*ENUMS.LUT"]

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -8,15 +8,19 @@ from pandablocks.blocking import BlockingClient
 def dummy_server_with_blocks(dummy_server_in_thread):
     dummy_server_in_thread.send += [
         "!PCAP 1\n!LUT 8\n.",
-        "OK =Description for PCAP field\nOK =Description for LUT field",
-        # TODO: Ask why no \n or '.' at end of above line
+        "OK =Description for PCAP block",
+        "OK =Description for LUT block",
         "!INPB 1 bit_mux\n!TYPEA 5 param enum\n.",  # LUT fields
         "!TRIG_EDGE 3 param enum\n!GATE 1 bit_mux\n.",  # PCAP fields
         # Next 4 lines deliberately concatenated so they are sent as one long response
-        "OK =LUT INPB Desc\n!TTLIN1.VAL\n!LVDSIN1.VAL\n.\n"
-        "OK =LUT TYPEA Desc\n!Input-Level\n!Pulse-On-Rising-Edge\n.\n"
-        "OK =PCAP GATE Desc\n!TTLIN1.VAL\n!LVDSIN1.VAL\n.\n"
-        "OK =PCAP TRIG_EDGE Desc\n!Rising\n!Falling\n.",
+        "OK =LUT INPB Desc",
+        "!TTLIN1.VAL\n!LVDSIN1.VAL\n.",
+        "OK =LUT TYPEA Desc",
+        "!Input-Level\n!Pulse-On-Rising-Edge\n.",
+        "OK =PCAP GATE Desc",
+        "!TTLIN1.VAL\n!LVDSIN1.VAL\n.",
+        "OK =PCAP TRIG_EDGE Desc",
+        "!Rising\n!Falling\n.",
     ]
     # TODO: Ask about DummyServer throwing an exception during these tests -is it
     # still a failure if that testware server throws exceptions?

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -7,20 +7,14 @@ from pandablocks.blocking import BlockingClient
 @pytest.fixture
 def dummy_server_with_blocks(dummy_server_in_thread):
     dummy_server_in_thread.send += [
-        "!PCAP 1\n!LUT 8\n.",
-        "OK =Description for PCAP block",
-        "OK =Description for LUT block",
+        "!PCAP 1\n!LUT 8\n!SRGATE 2\n.",
         "!INPB 1 bit_mux\n!TYPEA 5 param enum\n.",  # LUT fields
         "!TRIG_EDGE 3 param enum\n!GATE 1 bit_mux\n.",  # PCAP fields
-        # Next 4 lines deliberately concatenated so they are sent as one long response
-        "OK =LUT INPB Desc",
-        "!TTLIN1.VAL\n!LVDSIN1.VAL\n.",
-        "OK =LUT TYPEA Desc",
-        "!Input-Level\n!Pulse-On-Rising-Edge\n.",
-        "OK =PCAP GATE Desc",
-        "!TTLIN1.VAL\n!LVDSIN1.VAL\n.",
-        "OK =PCAP TRIG_EDGE Desc",
-        "!Rising\n!Falling\n.",
+        "!OUT 1 bit_out\n.",  # SRGATE fields
+        "!TTLIN1.VAL\n!LVDSIN1.VAL\n.",  # LUT.INPB labels
+        "!Input-Level\n!Pulse-On-Rising-Edge\n.",  # LUT.TYPEA labels
+        "!TTLIN1.VAL\n!LVDSIN1.VAL\n.",  # PCAP.GATE labels
+        "!Rising\n!Falling\n.",  # PCAP.TRIG_EDGE labels
     ]
     yield dummy_server_in_thread
 
@@ -55,7 +49,7 @@ def test_complete_stars(dummy_server_with_blocks):
             "*PCAP.DISARM=",
         ]
         assert completer("*DE", 0) == "*DESC.LUT"
-        assert completer.matches == ["*DESC.LUT", "*DESC.PCAP"]
+        assert completer.matches == ["*DESC.LUT", "*DESC.PCAP", "*DESC.SRGATE"]
         assert completer("*DESC.LUT.", 0) == "*DESC.LUT.INPB"
         assert completer.matches == ["*DESC.LUT.INPB", "*DESC.LUT.TYPEA"]
         assert completer("*ENUMS.LU", 0) == "*ENUMS.LUT"

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -10,8 +10,9 @@ def dummy_server_with_blocks(dummy_server_in_thread):
         "!PCAP 1\n!LUT 8\n.",
         "OK =Description for PCAP field\nOK =Description for LUT field",
         # TODO: Ask why no \n or '.' at end of above line
-        "!TYPEA 5 param enum\n!TYPEA_INP 1 bit_mux\n.",
-        "!TS_START 6 ext_out timestamp\n!ACTIVE 7 bit_out\n.",
+        "!INPB 1 bit_mux\n!TYPEA 5 param enum\n.",  # LUT fields
+        "!TRIG_EDGE 3 param enum\n!GATE 1 bit_mux\n.",  # PCAP fields
+        "OK =LUT INPB Desc\n!TTLIN1.VAL\n!LVDSIN1.VAL\n.\nOK =LUT TYPEA Desc\n!Input-Level\n!Pulse-On-Rising-Edge\n.\nOK =PCAP GATE Desc\n!TTLIN1.VAL\n!LVDSIN1.VAL\n.\nOK =PCAP TRIG_EDGE Desc\n!Rising\n!Falling\n.",
     ]
     yield dummy_server_in_thread
 
@@ -21,14 +22,16 @@ def test_complete_one_block(dummy_server_with_blocks):
         completer = BlockCompleter(client)
         assert completer("PCA", 0) == "PCAP"
         assert completer.matches == ["PCAP"]
-        assert completer("PCAP.", 0) == "PCAP.TS_START"
-        assert completer.matches == ["PCAP.TS_START", "PCAP.ACTIVE"]
+        assert completer("PCAP.", 0) == "PCAP.GATE"
+        assert completer.matches == ["PCAP.GATE", "PCAP.TRIG_EDGE"]
         completer("LU", 0)
         assert completer.matches == [f"LUT{i}" for i in range(1, 9)]
         completer("LUT5.", 0)
-        assert completer.matches == ["LUT5.TYPEA_INP", "LUT5.TYPEA"]
+        assert completer.matches == ["LUT5.INPB", "LUT5.TYPEA"]
         completer("LUT5.TYPEA_IN", 0)
-        assert completer.matches == ["LUT5.TYPEA_INP"]
+        assert completer.matches == []
+        completer("LUT5.TYPE", 0)
+        assert completer.matches == ["LUT5.TYPEA"]
         assert completer("LUT5.TYPEA_INP?", 0) is None
 
 

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -8,6 +8,8 @@ from pandablocks.blocking import BlockingClient
 def dummy_server_with_blocks(dummy_server_in_thread):
     dummy_server_in_thread.send += [
         "!PCAP 1\n!LUT 8\n.",
+        "Description for PCAP field\nDescription for LUT field",
+        # TODO: Ask why no \n or '.' at end of above line
         "!TYPEA 5 param enum\n!TYPEA_INP 1 bit_mux\n.",
         "!TS_START 6 ext_out timestamp\n!ACTIVE 7 bit_out\n.",
     ]

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -18,8 +18,8 @@ def dummy_server_with_blocks(dummy_server_in_thread):
         "OK =PCAP GATE Desc\n!TTLIN1.VAL\n!LVDSIN1.VAL\n.\n"
         "OK =PCAP TRIG_EDGE Desc\n!Rising\n!Falling\n.",
     ]
-    # TODO: Ask about DummyServer throwing an exception during these tests -is it still a failure
-    # if that testware server throws exceptions?
+    # TODO: Ask about DummyServer throwing an exception during these tests -is it
+    # still a failure if that testware server throws exceptions?
     yield dummy_server_in_thread
 
 

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -22,8 +22,6 @@ def dummy_server_with_blocks(dummy_server_in_thread):
         "OK =PCAP TRIG_EDGE Desc",
         "!Rising\n!Falling\n.",
     ]
-    # TODO: Ask about DummyServer throwing an exception during these tests -is it
-    # still a failure if that testware server throws exceptions?
     yield dummy_server_in_thread
 
 

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -8,7 +8,7 @@ from pandablocks.blocking import BlockingClient
 def dummy_server_with_blocks(dummy_server_in_thread):
     dummy_server_in_thread.send += [
         "!PCAP 1\n!LUT 8\n.",
-        "Description for PCAP field\nDescription for LUT field",
+        "OK =Description for PCAP field\nOK =Description for LUT field",
         # TODO: Ask why no \n or '.' at end of above line
         "!TYPEA 5 param enum\n!TYPEA_INP 1 bit_mux\n.",
         "!TS_START 6 ext_out timestamp\n!ACTIVE 7 bit_out\n.",

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -210,6 +210,24 @@ def test_get_fields_type_ext_out():
     ]
 
 
+def test_get_fields_non_existant_field():
+    """Test that querying for an unknown field returns a sensible error"""
+    conn = ControlConnection()
+    cmd = GetFieldInfo("FOO")
+    assert conn.send(cmd) == b"FOO.*?\n"
+
+    # Provide the error string the PandA would provide
+    assert conn.receive_bytes(b"ERR No such block\n") == b""
+
+    responses = get_responses(conn)
+    assert len(responses) == 1
+
+    response = responses[0]
+    assert response[0] == cmd
+    assert isinstance(response[1], CommandException)
+    assert response[1].args == ("GetFieldInfo(block='FOO') -> ERR No such block",)
+
+
 def test_get_pcap_bits_labels():
     """Simple working testcase for GetPcapBitsLabels"""
 

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -181,6 +181,25 @@ def test_get_pcap_bits_labels():
     ]
 
 
+def test_get_pcap_bits_labels_no_bits_fields():
+    """Test we get no response when no BITS fields are on the PandA"""
+
+    # PandA's return data when it receives "PCAP.*?"
+    PCAP_RETURN = [
+        "!SHIFT_SUM 4 param uint",
+        "!ACTIVE 5 bit_out",
+        "!ENABLE 0 bit_mux",
+        ".",
+    ]
+    conn = ControlConnection()
+    cmd = GetPcapBitsLabels()
+    assert conn.send(cmd) == b"PCAP.*?\n"
+
+    # As there are no BITS fields in the PCAP return, expect no response
+    response_bytes = "\n".join(PCAP_RETURN).encode() + b"\n"
+    assert conn.receive_bytes(response_bytes) == b""
+
+
 def test_save():
     conn = ControlConnection()
     cmd = GetState()

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -203,13 +203,13 @@ def test_get_fields():
                     type="bit_mux",
                     subtype=None,
                     description="Input A",
-                    label=["TTLIN1.VAL", "LVDSIN1.VAL"],
+                    labels=["TTLIN1.VAL", "LVDSIN1.VAL"],
                 ),
                 "TYPEA": FieldInfo(
                     type="param",
                     subtype="enum",
                     description="Source of the value of A for calculation",
-                    label=["Input-Level", "Pulse-On-Rising-Edge"],
+                    labels=["Input-Level", "Pulse-On-Rising-Edge"],
                 ),
             },
         )
@@ -247,7 +247,7 @@ def test_get_fields_type_ext_out():
                     type="ext_out",
                     subtype="samples",
                     description="Number of gated samples in the current capture",
-                    label=["No", "Value"],
+                    labels=["No", "Value"],
                 )
             },
         )

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -109,7 +109,7 @@ def test_get_block_info():
 
     # First of the *DESC.{block}? yields
     assert (
-        conn.receive_bytes(b"Description for PCAP field\n") == b""
+        conn.receive_bytes(b"OK =Description for PCAP field\n") == b""
     )  # No data returned as there's still one outstanding request
 
     # Create an OrderedDict of the output to test key order - that won't happen
@@ -124,7 +124,7 @@ def test_get_block_info():
     # Second and last of the *DESC.{block}? yields - as this is the last response we
     # can call get_responses to also get the overall result
     assert not get_responses(conn)
-    assert get_responses(conn, b"Description for LUT field\n") == [
+    assert get_responses(conn, b"OK =Description for LUT field\n") == [
         (cmd, ordered_dict,),
     ]
 

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -465,10 +465,6 @@ def test_save():
     )
     response_bytes = "\n".join(STATE_RESPONSES).encode() + b"\n"
     assert (
-        # TODO: This test is a bit broken - index 109 ends up chopping a word in half:
-        # \n.\n!ta <break> bledata\n.
-        # I think the index should be 107, but weirdly the test passes with a whole
-        # range of indexes around this number
         conn.receive_bytes(response_bytes[:107])
         == b"Table.B?\nMultiLineMeta1?\nMultiLineMeta2?\n"
     )

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -3,7 +3,6 @@ from typing import Iterator, OrderedDict
 import pytest
 
 from pandablocks.commands import (
-    BlockInfo,
     CommandException,
     FieldInfo,
     Get,
@@ -20,7 +19,7 @@ from pandablocks.connections import (
     DataConnection,
     NoContextAvailable,
 )
-from pandablocks.responses import Data
+from pandablocks.responses import BlockInfo, Data
 from tests.conftest import STATE_RESPONSES, STATE_SAVEFILE
 
 

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -125,10 +125,7 @@ def test_get_block_info():
     # can call get_responses to also get the overall result
     assert not get_responses(conn)
     assert get_responses(conn, b"Description for LUT field\n") == [
-        (
-            cmd,
-            ordered_dict,
-        ),
+        (cmd, ordered_dict,),
     ]
 
 

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -146,7 +146,9 @@ def test_get_block_info_error():
     response = responses[0]
     assert response[0] == cmd
     assert isinstance(response[1], CommandException)
-    assert response[1].args == ("GetBlockInfo() -> ERR Cannot read blocks",)
+    assert response[1].args == (
+        "GetBlockInfo(skip_description=False) -> ERR Cannot read blocks",
+    )
 
 
 def test_get_block_info_desc_err():
@@ -170,7 +172,7 @@ def test_get_block_info_desc_err():
     assert response[0] == cmd
     assert isinstance(response[1], CommandException)
     assert response[1].args == (
-        "GetBlockInfo() -> "
+        "GetBlockInfo(skip_description=False) -> "
         "ERR could not get description\nAssertionError:Line did not start with 'OK ='",
     )
 
@@ -272,7 +274,9 @@ def test_get_fields_non_existant_field():
     response = responses[0]
     assert response[0] == cmd
     assert isinstance(response[1], CommandException)
-    assert response[1].args == ("GetFieldInfo(block='FOO') -> ERR No such block",)
+    assert response[1].args == (
+        "GetFieldInfo(block='FOO', skip_description=False) -> ERR No such block",
+    )
 
 
 def test_get_pcap_bits_labels():

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -244,11 +244,15 @@ def test_save():
     )
     response_bytes = "\n".join(STATE_RESPONSES).encode() + b"\n"
     assert (
-        conn.receive_bytes(response_bytes[:109])
+        # TODO: This test is a bit broken - index 109 ends up chopping a word in half:
+        # \n.\n!ta <break> bledata\n.
+        # I think the index should be 107, but weirdly the test passes with a whole
+        # range of indexes around this number
+        conn.receive_bytes(response_bytes[:107])
         == b"Table.B?\nMultiLineMeta1?\nMultiLineMeta2?\n"
     )
     assert not get_responses(conn)
-    assert get_responses(conn, response_bytes[109:]) == [(cmd, STATE_SAVEFILE)]
+    assert get_responses(conn, response_bytes[107:]) == [(cmd, STATE_SAVEFILE)]
 
 
 def test_load():

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -14,7 +14,11 @@ from pandablocks.commands import (
     SetState,
     is_multiline_command,
 )
-from pandablocks.connections import ControlConnection, DataConnection
+from pandablocks.connections import (
+    ControlConnection,
+    DataConnection,
+    NoContextAvailable,
+)
 from pandablocks.responses import Data
 from tests.conftest import STATE_RESPONSES, STATE_SAVEFILE
 
@@ -121,7 +125,7 @@ def test_get_fields():
 
 
 def test_get_pcap_bits_labels():
-    """Simple working testcase"""
+    """Simple working testcase for GetPcapBitsLabels"""
 
     # PandA's return data when it receives "PCAP.*?"
     PCAP_RETURN = [
@@ -182,7 +186,7 @@ def test_get_pcap_bits_labels():
 
 
 def test_get_pcap_bits_labels_no_bits_fields():
-    """Test we get no response when no BITS fields are on the PandA"""
+    """Test we get no response when no BITS fields are returned by the PandA"""
 
     # PandA's return data when it receives "PCAP.*?"
     PCAP_RETURN = [
@@ -198,6 +202,15 @@ def test_get_pcap_bits_labels_no_bits_fields():
     # As there are no BITS fields in the PCAP return, expect no response
     response_bytes = "\n".join(PCAP_RETURN).encode() + b"\n"
     assert conn.receive_bytes(response_bytes) == b""
+
+
+def test_expected_exception_when_receive_without_send():
+    """Test that calling receive_bytes() without first calling send() raises the
+    expected exception"""
+
+    conn = ControlConnection()
+    with pytest.raises(NoContextAvailable):
+        conn.receive_bytes(b"abc\n")
 
 
 def test_save():

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -156,13 +156,14 @@ def test_get_block_info_error():
     # Provide error from PandA server
     assert conn.receive_bytes(b"ERR Cannot read blocks\n") == b""
 
-    responses = get_responses(conn)
-    assert len(responses) == 1
-
-    response = responses[0]
-    assert response[0] == cmd
-    assert isinstance(response[1], CommandException)
-    assert response[1].args == (repr(cmd) + " -> ERR Cannot read blocks",)
+    assert get_responses(conn) == [
+        (
+            cmd,
+            ACommandException(
+                "GetBlockInfo(skip_description=False) -> ERR Cannot read blocks"
+            ),
+        )
+    ]
 
 
 def test_get_block_info_desc_err():
@@ -179,16 +180,14 @@ def test_get_block_info_desc_err():
         conn.receive_bytes(b"ERR could not get description\n") == b""
     )  # No data returned as there's still one outstanding request
 
-    responses = get_responses(conn)
-    assert len(responses) == 1
-
-    response = responses[0]
-    assert response[0] == cmd
-    assert isinstance(response[1], CommandException)
-    assert response[1].args == (
-        repr(cmd) + " -> ERR could not get description\n"
-        "AssertionError:'ERR could not get description' does not start with 'OK ='",
-    )
+    assert get_responses(conn) == [
+        (
+            cmd,
+            ACommandException(
+                "GetBlockInfo(skip_description=False) -> ERR could not get description"
+            ),
+        )
+    ]
 
 
 def test_get_fields():
@@ -311,13 +310,14 @@ def test_get_fields_non_existant_field():
     # Provide the error string the PandA would provide
     assert conn.receive_bytes(b"ERR No such block\n") == b""
 
-    responses = get_responses(conn)
-    assert len(responses) == 1
-
-    response = responses[0]
-    assert response[0] == cmd
-    assert isinstance(response[1], CommandException)
-    assert response[1].args == (repr(cmd) + " -> ERR No such block",)
+    assert get_responses(conn) == [
+        (
+            cmd,
+            ACommandException(
+                "GetFieldInfo(block='FOO', skip_description=False) -> ERR No such block"
+            ),
+        )
+    ]
 
 
 def test_get_fields_no_enums():

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -187,7 +187,7 @@ def test_get_block_info_desc_err():
     assert isinstance(response[1], CommandException)
     assert response[1].args == (
         repr(cmd) + " -> ERR could not get description\n"
-        "AssertionError:Line did not start with 'OK ='",
+        "AssertionError:'ERR could not get description' does not start with 'OK ='",
     )
 
 

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -5,10 +5,10 @@ import pytest
 from pandablocks.commands import (
     BlockInfo,
     CommandException,
-    FieldType,
+    FieldInfo,
     Get,
     GetBlockInfo,
-    GetFields,
+    GetFieldInfo,
     GetPcapBitsLabels,
     GetState,
     Put,
@@ -131,15 +131,15 @@ def test_get_block_info():
 
 def test_get_fields():
     conn = ControlConnection()
-    cmd = GetFields("LUT")
+    cmd = GetFieldInfo("LUT")
     assert conn.send(cmd) == b"LUT.*?\n"
     responses = get_responses(conn, b"!TYPEA 5 param enum\n!INPA 1 bit_mux\n.\n")
     assert responses == [
         (
             cmd,
             dict(
-                INPA=FieldType(type="bit_mux"),
-                TYPEA=FieldType(type="param", subtype="enum"),
+                INPA=FieldInfo(type="bit_mux"),
+                TYPEA=FieldInfo(type="param", subtype="enum"),
             ),
         )
     ]

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -124,7 +124,10 @@ def test_get_block_info():
     # can call get_responses to also get the overall result
     assert not get_responses(conn)
     assert get_responses(conn, b"OK =Description for LUT field\n") == [
-        (cmd, ordered_dict,),
+        (
+            cmd,
+            ordered_dict,
+        ),
     ]
 
 


### PR DESCRIPTION
This PR creates/modifies the GetBlockInfo, GetFieldInfo, and GetPcapBitsLabels function to allow introspection of the blocks and fields provided on a PandA.

There are also a multitude of other minor changes/enhancements/fixes, to both code and configuration, including:

- Running mypy directly in VSCode
- Upgrading Black version to handle more auto-format situations for us (which resulted in some formatting changes in otherwise untouched files)
- Explicitly naming extra packages in the Pipfile to work around Pipenv issues where they would be incorrectly marked with incorrect Python version markers
- New documentation for introspecting a PandA, with example code
- Better reporting of some exceptions/assertions, found during testing

Closes #26
