### PR TITLE
Add extended FieldInfo dataclasses for all fields

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,32 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Introspect Panda",
+            "type": "python",
+            "request": "launch",
+            "program": "examples/introspect_panda.py",
+            "console": "integratedTerminal",
+            "args": [
+                "172.23.252.201"
+            ],
+            "justMyCode": false
+        },
+        {
             "name": "Debug Unit Test",
             "type": "python",
-            "request": "test",
-            "justMyCode": false,
+            "request": "launch",
+            "program": "${file}",
+            "purpose": [
+                "debug-test"
+            ],
+            "console": "integratedTerminal",
             "env": {
+                // Cannot have coverage and debugging at the same time,
+                // and the default config in setup.cfg adds coverage
+                //https://github.com/microsoft/vscode-python/issues/693
                 "PYTEST_ADDOPTS": "--no-cov"
-            }
+            },
+            "justMyCode": false
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,4 +14,8 @@
     "editor.codeActionsOnSave": {
         "source.organizeImports": true
     },
+    "[jsonc]": {
+        "editor.defaultFormatter": "vscode.json-language-features"
+    },
+    "python.analysis.typeCheckingMode": "off",
 }

--- a/Pipfile
+++ b/Pipfile
@@ -5,34 +5,35 @@ verify_ssl = true
 
 [dev-packages]
 # Pinning black stops us having to allow pre-releases globally
-black = "==21.7b0"
-
+black = "*"
 # Pins to make lockfile usable on multiple Python versions and platforms
 mypy = "*"
 atomicwrites = "*"
-typing-extensions = "*"
-importlib-metadata = "*"
 typed-ast = "*"
-
 # Test and docs dependencies
 pytest-cov = "*"
 pytest-mypy = "*"
+flake8 = "==4.0.1" # https://github.com/tholo/pytest-flake8/issues/87 - will stop being an issue when we move to a new skeleton
 pytest-flake8 = "*"
 pytest-black = "*"
+mock = "*"
+types-mock = "*"
 pytest-asyncio = "*"
 flake8-isort = "*"
 isort = ">5.0"
+sphinx = "==4.3.2"
 sphinx-rtd-theme = "*"
+aioca = "*"
 
 [packages]
 # All other package requirements from setup.cfg
 pandablocks = {editable = true, extras = ["hdf5"], path = "."}
 # Pins to make lockfile usable on multiple Python versions and platforms
 numpy = "*"
+typing-extensions = "*"
 
 [scripts]
 tests = "python -m pytest"
 docs = "sphinx-build -EWT --keep-going docs build/html"
 # Delete any files that git ignore hides from us
 gitclean = "git clean -fdX"
-

--- a/Pipfile
+++ b/Pipfile
@@ -23,7 +23,6 @@ flake8-isort = "*"
 isort = ">5.0"
 sphinx = "==4.3.2"
 sphinx-rtd-theme = "*"
-aioca = "*"
 
 [packages]
 # All other package requirements from setup.cfg

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "213e1133ca30cc822e88acf2b1366fdddecaea796a428d7fd6f1906684d8abf0"
+            "sha256": "90a12d4253e1ffb0b319b61c579831e4d73b4fbcc5c7c46620e93199757dc1dd"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,20 +14,12 @@
         ]
     },
     "default": {
-        "cached-property": {
-            "hashes": [
-                "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130",
-                "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.5.2"
-        },
         "click": {
             "hashes": [
-                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
-                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
             ],
-            "version": "==7.1.2"
+            "version": "==8.1.3"
         },
         "cycler": {
             "hashes": [
@@ -36,20 +28,45 @@
             ],
             "version": "==0.10.0"
         },
+        "fonttools": {
+            "hashes": [
+                "sha256:1933415e0fbdf068815cb1baaa1f159e17830215f7e8624e5731122761627557",
+                "sha256:2b18a172120e32128a80efee04cff487d5d140fe7d817deb648b2eee023a40e4"
+            ],
+            "version": "==4.29.1"
+        },
         "h5py": {
             "hashes": [
-                "sha256:09e78cefdef0b7566ab66366c5c7d9984c7b23142245bd51b82b744ad1eebf65",
-                "sha256:13355234c004ff8bd819f7d3420188aa1936b17d7f8470d622974a373421b7a5",
-                "sha256:5e2f22e66a3fb1815405cfe5711670450c973b8552507c535a546a23a468af3d",
-                "sha256:7ca7d23ebbdd59a4be9b4820de52fe67adc74e6a44d5084881305461765aac47",
-                "sha256:89d7e10409b62fed81c571e35798763cb8375442b98f8ebfc52ba41ac019e081",
-                "sha256:8e09b682e4059c8cd259ddcc34bee35d639b9170105efeeae6ad195e7c1cea7a",
-                "sha256:baef1a2cdef287a83e7f95ce9e0f4d762a9852fe7117b471063442c78b973695",
-                "sha256:e0dac887d779929778b3cfd13309a939359cc9e74756fc09af7c527a82797186",
-                "sha256:e0ea3330bf136f8213e43db67448994046ce501585dddc7ea4e8ceef0ef1600c",
-                "sha256:f3bba8ffddd1fd2bf06127c5ff7b73f022cc1c8b7164355ddc760dc3f8570136"
+                "sha256:03d64fb86bb86b978928bad923b64419a23e836499ec6363e305ad28afd9d287",
+                "sha256:04e2e1e2fc51b8873e972a08d2f89625ef999b1f2d276199011af57bb9fc7851",
+                "sha256:0798a9c0ff45f17d0192e4d7114d734cac9f8b2b2c76dd1d923c4d0923f27bb6",
+                "sha256:0a047fddbe6951bce40e9cde63373c838a978c5e05a011a682db9ba6334b8e85",
+                "sha256:0d8de8cb619fc597da7cf8cdcbf3b7ff8c5f6db836568afc7dc16d21f59b2b49",
+                "sha256:1fcb11a2dc8eb7ddcae08afd8fae02ba10467753a857fa07a404d700a93f3d53",
+                "sha256:3fcf37884383c5da64846ab510190720027dca0768def34dd8dcb659dbe5cbf3",
+                "sha256:43fed4d13743cf02798a9a03a360a88e589d81285e72b83f47d37bb64ed44881",
+                "sha256:63beb8b7b47d0896c50de6efb9a1eaa81dbe211f3767e7dd7db159cea51ba37a",
+                "sha256:6776d896fb90c5938de8acb925e057e2f9f28755f67ec3edcbc8344832616c38",
+                "sha256:9e2ad2aa000f5b1e73b5dfe22f358ca46bf1a2b6ca394d9659874d7fc251731a",
+                "sha256:9e7535df5ee3dc3e5d1f408fdfc0b33b46bc9b34db82743c82cd674d8239b9ad",
+                "sha256:a9351d729ea754db36d175098361b920573fdad334125f86ac1dd3a083355e20",
+                "sha256:c038399ce09a58ff8d89ec3e62f00aa7cb82d14f34e24735b920e2a811a3a426",
+                "sha256:d77af42cb751ad6cc44f11bae73075a07429a5cf2094dfde2b1e716e059b3911",
+                "sha256:e5b7820b75f9519499d76cc708e27242ccfdd9dfb511d6deb98701961d0445aa",
+                "sha256:ed43e2cc4f511756fd664fb45d6b66c3cbed4e3bd0f70e29c37809b2ae013c44",
+                "sha256:f084bbe816907dfe59006756f8f2d16d352faff2d107f4ffeb1d8de126fc5dc7",
+                "sha256:f514b24cacdd983e61f8d371edac8c1b780c279d0acb8485639e97339c866073",
+                "sha256:f73307c876af49aa869ec5df1818e9bb0bdcfcf8a5ba773cc45a4fba5a286a5c"
             ],
-            "version": "==3.3.0"
+            "version": "==3.7.0"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c",
+                "sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==4.11.1"
         },
         "kiwisolver": {
             "hashes": [
@@ -90,57 +107,87 @@
         },
         "matplotlib": {
             "hashes": [
-                "sha256:1f83a32e4b6045191f9d34e4dc68c0a17c870b57ef9cca518e516da591246e79",
-                "sha256:2eee37340ca1b353e0a43a33da79d0cd4bcb087064a0c3c3d1329cdea8fbc6f3",
-                "sha256:53ceb12ef44f8982b45adc7a0889a7e2df1d758e8b360f460e435abe8a8cd658",
-                "sha256:574306171b84cd6854c83dc87bc353cacc0f60184149fb00c9ea871eca8c1ecb",
-                "sha256:7561fd541477d41f3aa09457c434dd1f7604f3bd26d7858d52018f5dfe1c06d1",
-                "sha256:7a54efd6fcad9cb3cd5ef2064b5a3eeb0b63c99f26c346bdcf66e7c98294d7cc",
-                "sha256:7f16660edf9a8bcc0f766f51c9e1b9d2dc6ceff6bf636d2dbd8eb925d5832dfd",
-                "sha256:81e6fe8b18ef5be67f40a1d4f07d5a4ed21d3878530193898449ddef7793952f",
-                "sha256:84a10e462120aa7d9eb6186b50917ed5a6286ee61157bfc17c5b47987d1a9068",
-                "sha256:84d4c4f650f356678a5d658a43ca21a41fca13f9b8b00169c0b76e6a6a948908",
-                "sha256:86dc94e44403fa0f2b1dd76c9794d66a34e821361962fe7c4e078746362e3b14",
-                "sha256:90dbc007f6389bcfd9ef4fe5d4c78c8d2efe4e0ebefd48b4f221cdfed5672be2",
-                "sha256:9f374961a3996c2d1b41ba3145462c3708a89759e604112073ed6c8bdf9f622f",
-                "sha256:a18cc1ab4a35b845cf33b7880c979f5c609fd26c2d6e74ddfacb73dcc60dd956",
-                "sha256:a97781453ac79409ddf455fccf344860719d95142f9c334f2a8f3fff049ffec3",
-                "sha256:a989022f89cda417f82dbf65e0a830832afd8af743d05d1414fb49549287ff04",
-                "sha256:ac2a30a09984c2719f112a574b6543ccb82d020fd1b23b4d55bf4759ba8dd8f5",
-                "sha256:be4430b33b25e127fc4ea239cc386389de420be4d63e71d5359c20b562951ce1",
-                "sha256:c45e7bf89ea33a2adaef34774df4e692c7436a18a48bcb0e47a53e698a39fa39"
+                "sha256:0abf8b51cc6d3ba34d1b15b26e329f23879848a0cf1216954c1f432ffc7e1af7",
+                "sha256:0e020a42f3338823a393dd2f80e39a2c07b9f941dfe2c778eb104eeb33d60bb5",
+                "sha256:13930a0c9bec0fd25f43c448b047a21af1353328b946f044a8fc3be077c6b1a8",
+                "sha256:153a0cf6a6ff4f406a0600d2034710c49988bacc6313d193b32716f98a697580",
+                "sha256:18f6e52386300db5cc4d1e9019ad9da2e80658bab018834d963ebb0aa5355095",
+                "sha256:2089b9014792dcc87bb1d620cde847913338abf7d957ef05587382b0cb76d44e",
+                "sha256:2eea16883aa7724c95eea0eb473ab585c6cf66f0e28f7f13e63deb38f4fd6d0f",
+                "sha256:38892a254420d95594285077276162a5e9e9c30b6da08bdc2a4d53331ad9a6fa",
+                "sha256:4b018ea6f26424a0852eb60eb406420d9f0d34f65736ea7bbfbb104946a66d86",
+                "sha256:65f877882b7ddede7090c7d87be27a0f4720fe7fc6fddd4409c06e1aa0f1ae8d",
+                "sha256:666d717a4798eb9c5d3ae83fe80c7bc6ed696b93e879cb01cb24a74155c73612",
+                "sha256:66b172610db0ececebebb09d146f54205f87c7b841454e408fba854764f91bdd",
+                "sha256:6db02c5605f063b67780f4d5753476b6a4944343284aa4e93c5e8ff6e9ec7f76",
+                "sha256:6e0e6b2111165522ad336705499b1f968c34a9e84d05d498ee5af0b5697d1efe",
+                "sha256:71a1851111f23f82fc43d2b6b2bfdd3f760579a664ebc939576fe21cc6133d01",
+                "sha256:7a7cb59ebd63a8ac4542ec1c61dd08724f82ec3aa7bb6b4b9e212d43c611ce3d",
+                "sha256:7baf23adb698d8c6ca7339c9dde00931bc47b2dd82fa912827fef9f93db77f5e",
+                "sha256:970aa97297537540369d05fe0fd1bb952593f9ab696c9b427c06990a83e2418b",
+                "sha256:9bac8eb1eccef540d7f4e844b6313d9f7722efd48c07e1b4bfec1056132127fd",
+                "sha256:a07ff2565da72a7b384a9e000b15b6b8270d81370af8a3531a16f6fbcee023cc",
+                "sha256:a0dcaf5648cecddc328e81a0421821a1f65a1d517b20746c94a1f0f5c36fb51a",
+                "sha256:a0ea10faa3bab0714d3a19c7e0921279a68d57552414d6eceaea99f97d7735db",
+                "sha256:a5b62d1805cc83d755972033c05cea78a1e177a159fc84da5c9c4ab6303ccbd9",
+                "sha256:a6cef5b31e27c31253c0f852b629a38d550ae66ec6850129c49d872f9ee428cb",
+                "sha256:a7bf8b05c214d32fb7ca7c001fde70b9b426378e897b0adbf77b85ea3569d56a",
+                "sha256:ac17a7e7b06ee426a4989f0b7f24ab1a592e39cdf56353a90f4e998bc0bf44d6",
+                "sha256:b3b687e905da32e5f2e5f16efa713f5d1fcd9fb8b8c697895de35c91fedeb086",
+                "sha256:b5e439d9e55d645f2a4dca63e2f66d68fe974c405053b132d61c7e98c25dfeb2",
+                "sha256:ba107add08e12600b072cf3c47aaa1ab85dd4d3c48107a5d3377d1bf80f8b235",
+                "sha256:d092b7ba63182d2dd427904e3eb58dd5c46ec67c5968de14a4b5007010a3a4cc",
+                "sha256:dc8c5c23e7056e126275dbf29efba817b3d94196690930d0968873ac3a94ab82",
+                "sha256:df0042cab69f4d246f4cb8fc297770ac4ae6ec2983f61836b04a117722037dcd",
+                "sha256:ee3d9ff16d749a9aa521bd7d86f0dbf256b2d2ac8ce31b19e4d2c86d2f2ff0b6",
+                "sha256:f23fbf70d2e80f4e03a83fc1206a8306d9bc50482fee4239f10676ce7e470c83",
+                "sha256:ff5d9fe518ad2de14ce82ab906b6ab5c2b0c7f4f984400ff8a7a905daa580a0a"
             ],
-            "version": "==3.4.1"
+            "version": "==3.5.0"
         },
         "numpy": {
             "hashes": [
-                "sha256:2428b109306075d89d21135bdd6b785f132a1f5a3260c371cee1fae427e12727",
-                "sha256:377751954da04d4a6950191b20539066b4e19e3b559d4695399c5e8e3e683bf6",
-                "sha256:4703b9e937df83f5b6b7447ca5912b5f5f297aba45f91dbbbc63ff9278c7aa98",
-                "sha256:471c0571d0895c68da309dacee4e95a0811d0a9f9f532a48dc1bea5f3b7ad2b7",
-                "sha256:61d5b4cf73622e4d0c6b83408a16631b670fc045afd6540679aa35591a17fe6d",
-                "sha256:6c915ee7dba1071554e70a3664a839fbc033e1d6528199d4621eeaaa5487ccd2",
-                "sha256:6e51e417d9ae2e7848314994e6fc3832c9d426abce9328cf7571eefceb43e6c9",
-                "sha256:719656636c48be22c23641859ff2419b27b6bdf844b36a2447cb39caceb00935",
-                "sha256:780ae5284cb770ade51d4b4a7dce4faa554eb1d88a56d0e8b9f35fca9b0270ff",
-                "sha256:878922bf5ad7550aa044aa9301d417e2d3ae50f0f577de92051d739ac6096cee",
-                "sha256:924dc3f83de20437de95a73516f36e09918e9c9c18d5eac520062c49191025fb",
-                "sha256:97ce8b8ace7d3b9288d88177e66ee75480fb79b9cf745e91ecfe65d91a856042",
-                "sha256:9c0fab855ae790ca74b27e55240fe4f2a36a364a3f1ebcfd1fb5ac4088f1cec3",
-                "sha256:9cab23439eb1ebfed1aaec9cd42b7dc50fc96d5cd3147da348d9161f0501ada5",
-                "sha256:a8e6859913ec8eeef3dbe9aed3bf475347642d1cdd6217c30f28dee8903528e6",
-                "sha256:aa046527c04688af680217fffac61eec2350ef3f3d7320c07fd33f5c6e7b4d5f",
-                "sha256:abc81829c4039e7e4c30f7897938fa5d4916a09c2c7eb9b244b7a35ddc9656f4",
-                "sha256:bad70051de2c50b1a6259a6df1daaafe8c480ca98132da98976d8591c412e737",
-                "sha256:c73a7975d77f15f7f68dacfb2bca3d3f479f158313642e8ea9058eea06637931",
-                "sha256:d15007f857d6995db15195217afdbddfcd203dfaa0ba6878a2f580eaf810ecd6",
-                "sha256:d76061ae5cab49b83a8cf3feacefc2053fac672728802ac137dd8c4123397677",
-                "sha256:e8e4fbbb7e7634f263c5b0150a629342cc19b47c5eba8d1cd4363ab3455ab576",
-                "sha256:e9459f40244bb02b2f14f6af0cd0732791d72232bbb0dc4bab57ef88e75f6935",
-                "sha256:edb1f041a9146dcf02cd7df7187db46ab524b9af2515f392f337c7cbbf5b52cd"
+                "sha256:1dbe1c91269f880e364526649a52eff93ac30035507ae980d2fed33aaee633ac",
+                "sha256:357768c2e4451ac241465157a3e929b265dfac85d9214074985b1786244f2ef3",
+                "sha256:3820724272f9913b597ccd13a467cc492a0da6b05df26ea09e78b171a0bb9da6",
+                "sha256:4391bd07606be175aafd267ef9bea87cf1b8210c787666ce82073b05f202add1",
+                "sha256:4aa48afdce4660b0076a00d80afa54e8a97cd49f457d68a4342d188a09451c1a",
+                "sha256:58459d3bad03343ac4b1b42ed14d571b8743dc80ccbf27444f266729df1d6f5b",
+                "sha256:5c3c8def4230e1b959671eb959083661b4a0d2e9af93ee339c7dada6759a9470",
+                "sha256:5f30427731561ce75d7048ac254dbe47a2ba576229250fb60f0fb74db96501a1",
+                "sha256:643843bcc1c50526b3a71cd2ee561cf0d8773f062c8cbaf9ffac9fdf573f83ab",
+                "sha256:67c261d6c0a9981820c3a149d255a76918278a6b03b6a036800359aba1256d46",
+                "sha256:67f21981ba2f9d7ba9ade60c9e8cbaa8cf8e9ae51673934480e45cf55e953673",
+                "sha256:6aaf96c7f8cebc220cdfc03f1d5a31952f027dda050e5a703a0d1c396075e3e7",
+                "sha256:7c4068a8c44014b2d55f3c3f574c376b2494ca9cc73d2f1bd692382b6dffe3db",
+                "sha256:7c7e5fa88d9ff656e067876e4736379cc962d185d5cd808014a8a928d529ef4e",
+                "sha256:7f5ae4f304257569ef3b948810816bc87c9146e8c446053539947eedeaa32786",
+                "sha256:82691fda7c3f77c90e62da69ae60b5ac08e87e775b09813559f8901a88266552",
+                "sha256:8737609c3bbdd48e380d463134a35ffad3b22dc56295eff6f79fd85bd0eeeb25",
+                "sha256:9f411b2c3f3d76bba0865b35a425157c5dcf54937f82bbeb3d3c180789dd66a6",
+                "sha256:a6be4cb0ef3b8c9250c19cc122267263093eee7edd4e3fa75395dfda8c17a8e2",
+                "sha256:bcb238c9c96c00d3085b264e5c1a1207672577b93fa666c3b14a45240b14123a",
+                "sha256:bf2ec4b75d0e9356edea834d1de42b31fe11f726a81dfb2c2112bc1eaa508fcf",
+                "sha256:d136337ae3cc69aa5e447e78d8e1514be8c3ec9b54264e680cf0b4bd9011574f",
+                "sha256:d4bf4d43077db55589ffc9009c0ba0a94fa4908b9586d6ccce2e0b164c86303c",
+                "sha256:d6a96eef20f639e6a97d23e57dd0c1b1069a7b4fd7027482a4c5c451cd7732f4",
+                "sha256:d9caa9d5e682102453d96a0ee10c7241b72859b01a941a397fd965f23b3e016b",
+                "sha256:dd1c8f6bd65d07d3810b90d02eba7997e32abbdf1277a481d698969e921a3be0",
+                "sha256:e31f0bb5928b793169b87e3d1e070f2342b22d5245c755e2b81caa29756246c3",
+                "sha256:ecb55251139706669fdec2ff073c98ef8e9a84473e51e716211b41aa0f18e656",
+                "sha256:ee5ec40fdd06d62fe5d4084bef4fd50fd4bb6bfd2bf519365f569dc470163ab0",
+                "sha256:f17e562de9edf691a42ddb1eb4a5541c20dd3f9e65b09ded2beb0799c0cf29bb",
+                "sha256:fdffbfb6832cd0b300995a2b08b8f6fa9f6e856d562800fea9182316d99c4e8e"
             ],
             "index": "pypi",
-            "version": "==1.20.2"
+            "version": "==1.21.6"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "version": "==21.3"
         },
         "pandablocks": {
             "editable": true,
@@ -189,17 +236,24 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
             ],
-            "version": "==2.4.7"
+            "version": "==3.0.9"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
-                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "version": "==2.8.1"
+            "version": "==2.8.2"
+        },
+        "setuptools-scm": {
+            "hashes": [
+                "sha256:031e13af771d6f892b941adb6ea04545bbf91ebc5ce68c78aaf3fff6e1fb4844",
+                "sha256:7930f720905e03ccd1e1d821db521bff7ec2ac9cf0ceb6552dd73d24a45d3b02"
+            ],
+            "version": "==7.0.5"
         },
         "six": {
             "hashes": [
@@ -207,22 +261,45 @@
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
             "version": "==1.16.0"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "version": "==2.0.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
+                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
+            ],
+            "index": "pypi",
+            "version": "==4.4.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:3a7af91c3db40ec72dd9d154ae18e008c69efe8ca88dde4f9a731bb82fe2f9eb",
+                "sha256:972cfa31bc2fedd3fa838a51e9bc7e64b7fb725a8c00e7431554311f180e9980"
+            ],
+            "version": "==3.9.0"
         }
     },
     "develop": {
+        "aioca": {
+            "hashes": [
+                "sha256:27f013040cfeb180b646f455134845a2f34c5a8a6aebac71e10c74b32055c4e9",
+                "sha256:7151aa5483191d17c02d13205ce4e42e4b2535bd78b73415943f8c7bbb6bc854"
+            ],
+            "index": "pypi",
+            "version": "==1.5.1"
+        },
         "alabaster": {
             "hashes": [
                 "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359",
                 "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"
             ],
             "version": "==0.7.12"
-        },
-        "appdirs": {
-            "hashes": [
-                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
-                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
-            ],
-            "version": "==1.4.4"
         },
         "atomicwrites": {
             "hashes": [
@@ -234,154 +311,210 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
-                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
             ],
-            "version": "==21.2.0"
+            "version": "==22.1.0"
         },
         "babel": {
             "hashes": [
-                "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9",
-                "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"
+                "sha256:1ad3eca1c885218f6dce2ab67291178944f810a10a9b5f3cb8382a5a232b64fe",
+                "sha256:5ef4b3226b0180dedded4229651c8b0e1a3a6a2837d45a073272f313e4cf97f6"
             ],
-            "version": "==2.9.1"
+            "version": "==2.11.0"
         },
         "black": {
             "hashes": [
-                "sha256:1c7aa6ada8ee864db745b22790a32f94b2795c253a75d6d9b5e439ff10d23116",
-                "sha256:c8373c6491de9362e39271630b65b964607bc5c79c83783547d76c839b3aa219"
+                "sha256:0a12e4e1353819af41df998b02c6742643cfef58282915f781d0e4dd7a200411",
+                "sha256:0ad827325a3a634bae88ae7747db1a395d5ee02cf05d9aa7a9bd77dfb10e940c",
+                "sha256:32a4b17f644fc288c6ee2bafdf5e3b045f4eff84693ac069d87b1a347d861497",
+                "sha256:3b2c25f8dea5e8444bdc6788a2f543e1fb01494e144480bc17f806178378005e",
+                "sha256:4a098a69a02596e1f2a58a2a1c8d5a05d5a74461af552b371e82f9fa4ada8342",
+                "sha256:5107ea36b2b61917956d018bd25129baf9ad1125e39324a9b18248d362156a27",
+                "sha256:53198e28a1fb865e9fe97f88220da2e44df6da82b18833b588b1883b16bb5d41",
+                "sha256:5594efbdc35426e35a7defa1ea1a1cb97c7dbd34c0e49af7fb593a36bd45edab",
+                "sha256:5b879eb439094751185d1cfdca43023bc6786bd3c60372462b6f051efa6281a5",
+                "sha256:78dd85caaab7c3153054756b9fe8c611efa63d9e7aecfa33e533060cb14b6d16",
+                "sha256:792f7eb540ba9a17e8656538701d3eb1afcb134e3b45b71f20b25c77a8db7e6e",
+                "sha256:8ce13ffed7e66dda0da3e0b2eb1bdfc83f5812f66e09aca2b0978593ed636b6c",
+                "sha256:a05da0430bd5ced89176db098567973be52ce175a55677436a271102d7eaa3fe",
+                "sha256:a983526af1bea1e4cf6768e649990f28ee4f4137266921c2c3cee8116ae42ec3",
+                "sha256:bc4d4123830a2d190e9cc42a2e43570f82ace35c3aeb26a512a2102bce5af7ec",
+                "sha256:c3a73f66b6d5ba7288cd5d6dad9b4c9b43f4e8a4b789a94bf5abfb878c663eb3",
+                "sha256:ce957f1d6b78a8a231b18e0dd2d94a33d2ba738cd88a7fe64f53f659eea49fdd",
+                "sha256:cea1b2542d4e2c02c332e83150e41e3ca80dc0fb8de20df3c5e98e242156222c",
+                "sha256:d2c21d439b2baf7aa80d6dd4e3659259be64c6f49dfd0f32091063db0e006db4",
+                "sha256:d839150f61d09e7217f52917259831fe2b689f5c8e5e32611736351b89bb2a90",
+                "sha256:dd82842bb272297503cbec1a2600b6bfb338dae017186f8f215c8958f8acf869",
+                "sha256:e8166b7bfe5dcb56d325385bd1d1e0f635f24aae14b3ae437102dedc0c186747",
+                "sha256:e981e20ec152dfb3e77418fb616077937378b322d7b26aa1ff87717fb18b4875"
             ],
             "index": "pypi",
-            "version": "==21.7b0"
+            "version": "==22.8.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
-                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
-            "version": "==2021.5.30"
+            "version": "==2022.12.7"
         },
-        "chardet": {
+        "charset-normalizer": {
             "hashes": [
-                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
-                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
+                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "version": "==4.0.0"
+            "version": "==2.1.1"
         },
         "click": {
             "hashes": [
-                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
-                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
             ],
-            "version": "==7.1.2"
+            "version": "==8.1.3"
         },
         "coverage": {
-            "hashes": [
-                "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c",
-                "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6",
-                "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45",
-                "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a",
-                "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03",
-                "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529",
-                "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a",
-                "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a",
-                "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2",
-                "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6",
-                "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759",
-                "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53",
-                "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a",
-                "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4",
-                "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff",
-                "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502",
-                "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793",
-                "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb",
-                "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905",
-                "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821",
-                "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b",
-                "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81",
-                "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0",
-                "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b",
-                "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3",
-                "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184",
-                "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701",
-                "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a",
-                "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82",
-                "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638",
-                "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5",
-                "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083",
-                "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6",
-                "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90",
-                "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465",
-                "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a",
-                "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3",
-                "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e",
-                "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066",
-                "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf",
-                "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b",
-                "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae",
-                "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669",
-                "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873",
-                "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b",
-                "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6",
-                "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb",
-                "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160",
-                "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c",
-                "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079",
-                "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
-                "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
+            "extras": [
+                "toml"
             ],
-            "version": "==5.5"
+            "hashes": [
+                "sha256:027018943386e7b942fa832372ebc120155fd970837489896099f5cfa2890f79",
+                "sha256:11b990d520ea75e7ee8dcab5bc908072aaada194a794db9f6d7d5cfd19661e5a",
+                "sha256:12adf310e4aafddc58afdb04d686795f33f4d7a6fa67a7a9d4ce7d6ae24d949f",
+                "sha256:1431986dac3923c5945271f169f59c45b8802a114c8f548d611f2015133df77a",
+                "sha256:1ef221513e6f68b69ee9e159506d583d31aa3567e0ae84eaad9d6ec1107dddaa",
+                "sha256:20c8ac5386253717e5ccc827caad43ed66fea0efe255727b1053a8154d952398",
+                "sha256:2198ea6fc548de52adc826f62cb18554caedfb1d26548c1b7c88d8f7faa8f6ba",
+                "sha256:255758a1e3b61db372ec2736c8e2a1fdfaf563977eedbdf131de003ca5779b7d",
+                "sha256:265de0fa6778d07de30bcf4d9dc471c3dc4314a23a3c6603d356a3c9abc2dfcf",
+                "sha256:33a7da4376d5977fbf0a8ed91c4dffaaa8dbf0ddbf4c8eea500a2486d8bc4d7b",
+                "sha256:42eafe6778551cf006a7c43153af1211c3aaab658d4d66fa5fcc021613d02518",
+                "sha256:4433b90fae13f86fafff0b326453dd42fc9a639a0d9e4eec4d366436d1a41b6d",
+                "sha256:4a5375e28c5191ac38cca59b38edd33ef4cc914732c916f2929029b4bfb50795",
+                "sha256:4a8dbc1f0fbb2ae3de73eb0bdbb914180c7abfbf258e90b311dcd4f585d44bd2",
+                "sha256:59f53f1dc5b656cafb1badd0feb428c1e7bc19b867479ff72f7a9dd9b479f10e",
+                "sha256:5dbec3b9095749390c09ab7c89d314727f18800060d8d24e87f01fb9cfb40b32",
+                "sha256:633713d70ad6bfc49b34ead4060531658dc6dfc9b3eb7d8a716d5873377ab745",
+                "sha256:6b07130585d54fe8dff3d97b93b0e20290de974dc8177c320aeaf23459219c0b",
+                "sha256:6c4459b3de97b75e3bd6b7d4b7f0db13f17f504f3d13e2a7c623786289dd670e",
+                "sha256:6d4817234349a80dbf03640cec6109cd90cba068330703fa65ddf56b60223a6d",
+                "sha256:723e8130d4ecc8f56e9a611e73b31219595baa3bb252d539206f7bbbab6ffc1f",
+                "sha256:784f53ebc9f3fd0e2a3f6a78b2be1bd1f5575d7863e10c6e12504f240fd06660",
+                "sha256:7b6be138d61e458e18d8e6ddcddd36dd96215edfe5f1168de0b1b32635839b62",
+                "sha256:7ccf362abd726b0410bf8911c31fbf97f09f8f1061f8c1cf03dfc4b6372848f6",
+                "sha256:83516205e254a0cb77d2d7bb3632ee019d93d9f4005de31dca0a8c3667d5bc04",
+                "sha256:851cf4ff24062c6aec510a454b2584f6e998cada52d4cb58c5e233d07172e50c",
+                "sha256:8f830ed581b45b82451a40faabb89c84e1a998124ee4212d440e9c6cf70083e5",
+                "sha256:94e2565443291bd778421856bc975d351738963071e9b8839ca1fc08b42d4bef",
+                "sha256:95203854f974e07af96358c0b261f1048d8e1083f2de9b1c565e1be4a3a48cfc",
+                "sha256:97117225cdd992a9c2a5515db1f66b59db634f59d0679ca1fa3fe8da32749cae",
+                "sha256:98e8a10b7a314f454d9eff4216a9a94d143a7ee65018dd12442e898ee2310578",
+                "sha256:a1170fa54185845505fbfa672f1c1ab175446c887cce8212c44149581cf2d466",
+                "sha256:a6b7d95969b8845250586f269e81e5dfdd8ff828ddeb8567a4a2eaa7313460c4",
+                "sha256:a8fb6cf131ac4070c9c5a3e21de0f7dc5a0fbe8bc77c9456ced896c12fcdad91",
+                "sha256:af4fffaffc4067232253715065e30c5a7ec6faac36f8fc8d6f64263b15f74db0",
+                "sha256:b4a5be1748d538a710f87542f22c2cad22f80545a847ad91ce45e77417293eb4",
+                "sha256:b5604380f3415ba69de87a289a2b56687faa4fe04dbee0754bfcae433489316b",
+                "sha256:b9023e237f4c02ff739581ef35969c3739445fb059b060ca51771e69101efffe",
+                "sha256:bc8ef5e043a2af066fa8cbfc6e708d58017024dc4345a1f9757b329a249f041b",
+                "sha256:c4ed2820d919351f4167e52425e096af41bfabacb1857186c1ea32ff9983ed75",
+                "sha256:cca4435eebea7962a52bdb216dec27215d0df64cf27fc1dd538415f5d2b9da6b",
+                "sha256:d900bb429fdfd7f511f868cedd03a6bbb142f3f9118c09b99ef8dc9bf9643c3c",
+                "sha256:d9ecf0829c6a62b9b573c7bb6d4dcd6ba8b6f80be9ba4fc7ed50bf4ac9aecd72",
+                "sha256:dbdb91cd8c048c2b09eb17713b0c12a54fbd587d79adcebad543bc0cd9a3410b",
+                "sha256:de3001a203182842a4630e7b8d1a2c7c07ec1b45d3084a83d5d227a3806f530f",
+                "sha256:e07f4a4a9b41583d6eabec04f8b68076ab3cd44c20bd29332c6572dda36f372e",
+                "sha256:ef8674b0ee8cc11e2d574e3e2998aea5df5ab242e012286824ea3c6970580e53",
+                "sha256:f4f05d88d9a80ad3cac6244d36dd89a3c00abc16371769f1340101d3cb899fc3",
+                "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84",
+                "sha256:fc2af30ed0d5ae0b1abdb4ebdce598eafd5b35397d4d75deb341a614d333d987"
+            ],
+            "version": "==6.5.0"
         },
         "docutils": {
             "hashes": [
-                "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
-                "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
+                "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125",
+                "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"
             ],
-            "version": "==0.16"
+            "version": "==0.17.1"
+        },
+        "epicscorelibs": {
+            "hashes": [
+                "sha256:05778faad8a5010708084e1047a15c46c1c44c19f9b3532d49480ff267cd59c9",
+                "sha256:0f07bddd3483f148b90b3351f6e5de6628fedb6e2262ccb219519731f81392b5",
+                "sha256:12d8f72efcfacfc785d5ad42bf0a5e76aac84f08f0f04570efa8a3fab132ae49",
+                "sha256:194155e170e7473fe8a6999489bd089e84a172955ec8db0d66155dc92a60c14c",
+                "sha256:22bef19a81de7b099b45dbbb8730c8aeb3e727f9e0609ba461835db35de75c9c",
+                "sha256:2e0d05a62c5fc0f126fc8e7924020c81257581d903255379e78720d7056a427c",
+                "sha256:3ab4ff529d8cd183f61d53a130b3ca4cf85b055bbc05b5607adfda3d10bb3674",
+                "sha256:415b98a44f75cb00563e47670bb8b233d0a47fde5bcf263deb828483062e9d99",
+                "sha256:48e1c63a0f5d06bb75a74f638fc10a31c87b5673708fda7ce1ec2e4319d33a17",
+                "sha256:4d06e2273ad4575e68278e64cac5ce4febea1e0110fc4a3aeec46c7a09fc71d2",
+                "sha256:5711e66be4bff06e198b3c90b9ee5b7e48017b4cc32c2245eb7e0581c889ff42",
+                "sha256:639e36fa63541d2a5903a3eda5fa1b832b94ed5c7131eeb68f02f07af56af3bb",
+                "sha256:68811552b3eae9f84c472a55775afcc13c66cb855207c08e19458a25d1b91765",
+                "sha256:76829079cda005ac1a8ad1231043199b1609bde3862e2ada92daf715d0aa6a5b",
+                "sha256:7d04129c2d1d3554a795f1c1fc97838999f198352b14854d16160c449879089a",
+                "sha256:8fdb1648f7873083a41b466d0428bc4076c6b73772bfab17a5b1a19011f7f8ef",
+                "sha256:9fd10d3f1fefd96f2b0751f65fa44791b978521b4a020cb5105cdbd80a0fcf84",
+                "sha256:a3e8a8482334087554f143f9cacb3393850378249196c2c53c8335bf44cf7a23",
+                "sha256:bbc444b4835c9742e40b94a1c590f1841453c40d51add8ce3a76599a0c02534a",
+                "sha256:be4dfa2518d336341162a217708ca18451b54db59b54c7685357d11efa00baac",
+                "sha256:c2aad6b3068a1dc9ccfd6bdc38886bd1ffa0bd96a429f3f05c1b97b2363095fa",
+                "sha256:c8060993f7628c9b445b6bb2080cf5fef8869e6e9fbd75398756f5b910528dda",
+                "sha256:d08cd4b228d7087fd172b9b48d5ebc1c763b6c1fbda26369776d5b274f1c73b4",
+                "sha256:d42a4342cbdb2c6452b6482f0e59a5043ca0c4c41ac6d48d1cb382c0257f9b85",
+                "sha256:dda6066046096aeb23c7fa7f7bef519316a8eb1f6e46b0859cdc614c03054d08",
+                "sha256:e277d538c531407f4926f8bfe4d06389b2a3fff9671000e11f2f2aa10cadce41",
+                "sha256:ebade58f5430ee2a597b56080cfff800389016c02aa33f394f2796d73e5d52d4",
+                "sha256:f136ef89acc19bb855f53ad29a768ecfbafcc22bd355eec8c17164c2735c5ecc"
+            ],
+            "version": "==7.0.7.99.0.0"
         },
         "filelock": {
             "hashes": [
-                "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
-                "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"
+                "sha256:7565f628ea56bfcd8e54e42bdc55da899c85c1abfe1b5bcfd147e9188cebb3b2",
+                "sha256:8df285554452285f79c035efb0c861eb33a4bcfa5b7a137016e32e6a90f9792c"
             ],
-            "version": "==3.0.12"
+            "version": "==3.8.2"
         },
         "flake8": {
             "hashes": [
-                "sha256:1aa8990be1e689d96c745c5682b687ea49f2e05a443aff1f8251092b0014e378",
-                "sha256:3b9f848952dddccf635be78098ca75010f073bfe14d2c6bda867154bea728d2a"
+                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
+                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
             ],
-            "version": "==3.9.1"
+            "index": "pypi",
+            "version": "==4.0.1"
         },
         "flake8-isort": {
             "hashes": [
-                "sha256:2b91300f4f1926b396c2c90185844eb1a3d5ec39ea6138832d119da0a208f4d9",
-                "sha256:729cd6ef9ba3659512dee337687c05d79c78e1215fdf921ed67e5fe46cce2f3c"
+                "sha256:0951398c343c67f4933407adbbfb495d4df7c038650c5d05753a006efcfeb390",
+                "sha256:8c4ab431d87780d0c8336e9614e50ef11201bc848ef64ca017532dec39d4bf49"
             ],
             "index": "pypi",
-            "version": "==4.0.0"
+            "version": "==5.0.3"
         },
         "idna": {
             "hashes": [
-                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
-            "version": "==2.10"
+            "version": "==3.4"
         },
         "imagesize": {
             "hashes": [
-                "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
-                "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
+                "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b",
+                "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"
             ],
-            "version": "==1.2.0"
+            "version": "==1.4.1"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:4a5611fea3768d3d967c447ab4e93f567d95db92225b43b7b238dbfb855d70bb",
-                "sha256:c6513572926a96458f8c8f725bf0e00108fba0c9583ade9bd15b869c9d726e33"
+                "sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c",
+                "sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094"
             ],
-            "index": "pypi",
-            "version": "==4.6.0"
+            "markers": "python_version < '3.8'",
+            "version": "==4.11.1"
         },
         "iniconfig": {
             "hashes": [
@@ -392,75 +525,63 @@
         },
         "isort": {
             "hashes": [
-                "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6",
-                "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"
+                "sha256:dd8bbc5c0990f2a095d754e50360915f73b4c26fc82733eb5bfc6b48396af4d2",
+                "sha256:e486966fba83f25b8045f8dd7455b0a0d1e4de481e1d7ce4669902d9fb85e622"
             ],
             "index": "pypi",
-            "version": "==5.8.0"
+            "version": "==5.11.2"
         },
         "jinja2": {
             "hashes": [
-                "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419",
-                "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
+                "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852",
+                "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"
             ],
-            "version": "==2.11.3"
+            "version": "==3.1.2"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
-                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
-                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
-                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
-                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
-                "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f",
-                "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39",
-                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
-                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
-                "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014",
-                "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f",
-                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
-                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
-                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
-                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
-                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
-                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
-                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
-                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
-                "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85",
-                "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1",
-                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
-                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
-                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
-                "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850",
-                "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0",
-                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
-                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
-                "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb",
-                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
-                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
-                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
-                "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1",
-                "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2",
-                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
-                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
-                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
-                "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7",
-                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
-                "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8",
-                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
-                "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193",
-                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
-                "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b",
-                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
-                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
-                "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5",
-                "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c",
-                "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032",
-                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
-                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be",
-                "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"
+                "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003",
+                "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88",
+                "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5",
+                "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7",
+                "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a",
+                "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603",
+                "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1",
+                "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135",
+                "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247",
+                "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6",
+                "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601",
+                "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
+                "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02",
+                "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e",
+                "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63",
+                "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f",
+                "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980",
+                "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b",
+                "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
+                "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff",
+                "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96",
+                "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1",
+                "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925",
+                "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a",
+                "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6",
+                "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e",
+                "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f",
+                "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4",
+                "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
+                "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3",
+                "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c",
+                "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a",
+                "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417",
+                "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
+                "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a",
+                "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37",
+                "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452",
+                "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933",
+                "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
+                "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"
             ],
-            "version": "==1.1.1"
+            "version": "==2.1.1"
         },
         "mccabe": {
             "hashes": [
@@ -469,34 +590,49 @@
             ],
             "version": "==0.6.1"
         },
-        "mypy": {
+        "mock": {
             "hashes": [
-                "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9",
-                "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a",
-                "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9",
-                "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e",
-                "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2",
-                "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212",
-                "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b",
-                "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885",
-                "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150",
-                "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703",
-                "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072",
-                "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457",
-                "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e",
-                "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0",
-                "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb",
-                "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97",
-                "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8",
-                "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811",
-                "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6",
-                "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de",
-                "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504",
-                "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921",
-                "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"
+                "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62",
+                "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"
             ],
             "index": "pypi",
-            "version": "==0.910"
+            "version": "==4.0.3"
+        },
+        "mypy": {
+            "hashes": [
+                "sha256:0714258640194d75677e86c786e80ccf294972cc76885d3ebbb560f11db0003d",
+                "sha256:0c8f3be99e8a8bd403caa8c03be619544bc2c77a7093685dcf308c6b109426c6",
+                "sha256:0cca5adf694af539aeaa6ac633a7afe9bbd760df9d31be55ab780b77ab5ae8bf",
+                "sha256:1c8cd4fb70e8584ca1ed5805cbc7c017a3d1a29fb450621089ffed3e99d1857f",
+                "sha256:1f7d1a520373e2272b10796c3ff721ea1a0712288cafaa95931e66aa15798813",
+                "sha256:209ee89fbb0deed518605edddd234af80506aec932ad28d73c08f1400ef80a33",
+                "sha256:26efb2fcc6b67e4d5a55561f39176821d2adf88f2745ddc72751b7890f3194ad",
+                "sha256:37bd02ebf9d10e05b00d71302d2c2e6ca333e6c2a8584a98c00e038db8121f05",
+                "sha256:3a700330b567114b673cf8ee7388e949f843b356a73b5ab22dd7cff4742a5297",
+                "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06",
+                "sha256:3d80e36b7d7a9259b740be6d8d906221789b0d836201af4234093cae89ced0cd",
+                "sha256:4175593dc25d9da12f7de8de873a33f9b2b8bdb4e827a7cae952e5b1a342e243",
+                "sha256:4307270436fd7694b41f913eb09210faff27ea4979ecbcd849e57d2da2f65305",
+                "sha256:5e80e758243b97b618cdf22004beb09e8a2de1af481382e4d84bc52152d1c476",
+                "sha256:641411733b127c3e0dab94c45af15fea99e4468f99ac88b39efb1ad677da5711",
+                "sha256:652b651d42f155033a1967739788c436491b577b6a44e4c39fb340d0ee7f0d70",
+                "sha256:6d7464bac72a85cb3491c7e92b5b62f3dcccb8af26826257760a552a5e244aa5",
+                "sha256:74e259b5c19f70d35fcc1ad3d56499065c601dfe94ff67ae48b85596b9ec1461",
+                "sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab",
+                "sha256:901c2c269c616e6cb0998b33d4adbb4a6af0ac4ce5cd078afd7bc95830e62c1c",
+                "sha256:98e781cd35c0acf33eb0295e8b9c55cdbef64fcb35f6d3aa2186f289bed6e80d",
+                "sha256:a12c56bf73cdab116df96e4ff39610b92a348cc99a1307e1da3c3768bbb5b135",
+                "sha256:ac6e503823143464538efda0e8e356d871557ef60ccd38f8824a4257acc18d93",
+                "sha256:b8472f736a5bfb159a5e36740847808f6f5b659960115ff29c7cecec1741c648",
+                "sha256:b86ce2c1866a748c0f6faca5232059f881cda6dda2a893b9a8373353cfe3715a",
+                "sha256:bc9ec663ed6c8f15f4ae9d3c04c989b744436c16d26580eaa760ae9dd5d662eb",
+                "sha256:c9166b3f81a10cdf9b49f2d594b21b31adadb3d5e9db9b834866c3258b695be3",
+                "sha256:d13674f3fb73805ba0c45eb6c0c3053d218aa1f7abead6e446d474529aafc372",
+                "sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb",
+                "sha256:e62ebaad93be3ad1a828a11e90f0e76f15449371ffeecca4a0a0b9adc99abcef"
+            ],
+            "index": "pypi",
+            "version": "==0.991"
         },
         "mypy-extensions": {
             "hashes": [
@@ -505,76 +641,120 @@
             ],
             "version": "==0.4.3"
         },
+        "numpy": {
+            "hashes": [
+                "sha256:1dbe1c91269f880e364526649a52eff93ac30035507ae980d2fed33aaee633ac",
+                "sha256:357768c2e4451ac241465157a3e929b265dfac85d9214074985b1786244f2ef3",
+                "sha256:3820724272f9913b597ccd13a467cc492a0da6b05df26ea09e78b171a0bb9da6",
+                "sha256:4391bd07606be175aafd267ef9bea87cf1b8210c787666ce82073b05f202add1",
+                "sha256:4aa48afdce4660b0076a00d80afa54e8a97cd49f457d68a4342d188a09451c1a",
+                "sha256:58459d3bad03343ac4b1b42ed14d571b8743dc80ccbf27444f266729df1d6f5b",
+                "sha256:5c3c8def4230e1b959671eb959083661b4a0d2e9af93ee339c7dada6759a9470",
+                "sha256:5f30427731561ce75d7048ac254dbe47a2ba576229250fb60f0fb74db96501a1",
+                "sha256:643843bcc1c50526b3a71cd2ee561cf0d8773f062c8cbaf9ffac9fdf573f83ab",
+                "sha256:67c261d6c0a9981820c3a149d255a76918278a6b03b6a036800359aba1256d46",
+                "sha256:67f21981ba2f9d7ba9ade60c9e8cbaa8cf8e9ae51673934480e45cf55e953673",
+                "sha256:6aaf96c7f8cebc220cdfc03f1d5a31952f027dda050e5a703a0d1c396075e3e7",
+                "sha256:7c4068a8c44014b2d55f3c3f574c376b2494ca9cc73d2f1bd692382b6dffe3db",
+                "sha256:7c7e5fa88d9ff656e067876e4736379cc962d185d5cd808014a8a928d529ef4e",
+                "sha256:7f5ae4f304257569ef3b948810816bc87c9146e8c446053539947eedeaa32786",
+                "sha256:82691fda7c3f77c90e62da69ae60b5ac08e87e775b09813559f8901a88266552",
+                "sha256:8737609c3bbdd48e380d463134a35ffad3b22dc56295eff6f79fd85bd0eeeb25",
+                "sha256:9f411b2c3f3d76bba0865b35a425157c5dcf54937f82bbeb3d3c180789dd66a6",
+                "sha256:a6be4cb0ef3b8c9250c19cc122267263093eee7edd4e3fa75395dfda8c17a8e2",
+                "sha256:bcb238c9c96c00d3085b264e5c1a1207672577b93fa666c3b14a45240b14123a",
+                "sha256:bf2ec4b75d0e9356edea834d1de42b31fe11f726a81dfb2c2112bc1eaa508fcf",
+                "sha256:d136337ae3cc69aa5e447e78d8e1514be8c3ec9b54264e680cf0b4bd9011574f",
+                "sha256:d4bf4d43077db55589ffc9009c0ba0a94fa4908b9586d6ccce2e0b164c86303c",
+                "sha256:d6a96eef20f639e6a97d23e57dd0c1b1069a7b4fd7027482a4c5c451cd7732f4",
+                "sha256:d9caa9d5e682102453d96a0ee10c7241b72859b01a941a397fd965f23b3e016b",
+                "sha256:dd1c8f6bd65d07d3810b90d02eba7997e32abbdf1277a481d698969e921a3be0",
+                "sha256:e31f0bb5928b793169b87e3d1e070f2342b22d5245c755e2b81caa29756246c3",
+                "sha256:ecb55251139706669fdec2ff073c98ef8e9a84473e51e716211b41aa0f18e656",
+                "sha256:ee5ec40fdd06d62fe5d4084bef4fd50fd4bb6bfd2bf519365f569dc470163ab0",
+                "sha256:f17e562de9edf691a42ddb1eb4a5541c20dd3f9e65b09ded2beb0799c0cf29bb",
+                "sha256:fdffbfb6832cd0b300995a2b08b8f6fa9f6e856d562800fea9182316d99c4e8e"
+            ],
+            "index": "pypi",
+            "version": "==1.21.6"
+        },
         "packaging": {
             "hashes": [
-                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
-                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
-            "version": "==20.9"
+            "version": "==21.3"
         },
         "pathspec": {
             "hashes": [
-                "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd",
-                "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"
+                "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93",
+                "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"
             ],
-            "version": "==0.8.1"
+            "version": "==0.10.1"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
+                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
+            ],
+            "version": "==2.5.2"
         },
         "pluggy": {
             "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "version": "==0.13.1"
+            "version": "==1.0.0"
         },
         "py": {
             "hashes": [
-                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
-                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
             ],
-            "version": "==1.10.0"
+            "version": "==1.11.0"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068",
-                "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"
+                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
             ],
-            "version": "==2.7.0"
+            "version": "==2.8.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3",
-                "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"
+                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
+                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
             ],
-            "version": "==2.3.1"
+            "version": "==2.4.0"
         },
         "pygments": {
             "hashes": [
-                "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f",
-                "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"
+                "sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1",
+                "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"
             ],
-            "version": "==2.9.0"
+            "version": "==2.13.0"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
             ],
-            "version": "==2.4.7"
+            "version": "==3.0.9"
         },
         "pytest": {
             "hashes": [
-                "sha256:671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634",
-                "sha256:6ad9c7bdf517a808242b998ac20063c41532a570d088d77eec1ee12b0b5574bc"
+                "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
+                "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
             ],
-            "version": "==6.2.3"
+            "version": "==7.1.3"
         },
         "pytest-asyncio": {
             "hashes": [
-                "sha256:2eae1e34f6c68fc0a9dc12d4bea190483843ff4708d24277c41568d6b6044f1d",
-                "sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700"
+                "sha256:6d895b02432c028e6957d25fc936494e78c6305736e785d9fee408b1efbc7ff4",
+                "sha256:e0fe5dbea40516b661ef1bcfe0bd9461c2847c4ef4bb40012324f2454fb7d56d"
             ],
             "index": "pypi",
-            "version": "==0.14.0"
+            "version": "==0.17.2"
         },
         "pytest-black": {
             "hashes": [
@@ -585,19 +765,19 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7",
-                "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"
+                "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b",
+                "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"
             ],
             "index": "pypi",
-            "version": "==2.11.1"
+            "version": "==4.0.0"
         },
         "pytest-flake8": {
             "hashes": [
-                "sha256:c28cf23e7d359753c896745fd4ba859495d02e16c84bac36caa8b1eec58f5bc1",
-                "sha256:f0259761a903563f33d6f099914afef339c085085e643bee8343eb323b32dd6b"
+                "sha256:ba4f243de3cb4c2486ed9e70752c80dd4b636f7ccb27d4eba763c35ed0cd316e",
+                "sha256:e0661a786f8cbf976c185f706fdaf5d6df0b1667c3bcff8e823ba263618627e7"
             ],
             "index": "pypi",
-            "version": "==1.0.7"
+            "version": "==1.1.1"
         },
         "pytest-mypy": {
             "hashes": [
@@ -609,85 +789,47 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
-                "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"
+                "sha256:2c0784747071402c6e99f0bafdb7da0fa22645f06554c7ae06bf6358897e9c91",
+                "sha256:48ce799d83b6f8aab2020e369b627446696619e79645419610b9facd909b3174"
             ],
-            "version": "==2021.1"
-        },
-        "regex": {
-            "hashes": [
-                "sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5",
-                "sha256:11d773d75fa650cd36f68d7ca936e3c7afaae41b863b8c387a22aaa78d3c5c79",
-                "sha256:18c071c3eb09c30a264879f0d310d37fe5d3a3111662438889ae2eb6fc570c31",
-                "sha256:1e1c20e29358165242928c2de1482fb2cf4ea54a6a6dea2bd7a0e0d8ee321500",
-                "sha256:281d2fd05555079448537fe108d79eb031b403dac622621c78944c235f3fcf11",
-                "sha256:314d66636c494ed9c148a42731b3834496cc9a2c4251b1661e40936814542b14",
-                "sha256:32e65442138b7b76dd8173ffa2cf67356b7bc1768851dded39a7a13bf9223da3",
-                "sha256:339456e7d8c06dd36a22e451d58ef72cef293112b559010db3d054d5560ef439",
-                "sha256:3916d08be28a1149fb97f7728fca1f7c15d309a9f9682d89d79db75d5e52091c",
-                "sha256:3a9cd17e6e5c7eb328517969e0cb0c3d31fd329298dd0c04af99ebf42e904f82",
-                "sha256:47bf5bf60cf04d72bf6055ae5927a0bd9016096bf3d742fa50d9bf9f45aa0711",
-                "sha256:4c46e22a0933dd783467cf32b3516299fb98cfebd895817d685130cc50cd1093",
-                "sha256:4c557a7b470908b1712fe27fb1ef20772b78079808c87d20a90d051660b1d69a",
-                "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb",
-                "sha256:563085e55b0d4fb8f746f6a335893bda5c2cef43b2f0258fe1020ab1dd874df8",
-                "sha256:598585c9f0af8374c28edd609eb291b5726d7cbce16be6a8b95aa074d252ee17",
-                "sha256:619d71c59a78b84d7f18891fe914446d07edd48dc8328c8e149cbe0929b4e000",
-                "sha256:67bdb9702427ceddc6ef3dc382455e90f785af4c13d495f9626861763ee13f9d",
-                "sha256:6d1b01031dedf2503631d0903cb563743f397ccaf6607a5e3b19a3d76fc10480",
-                "sha256:741a9647fcf2e45f3a1cf0e24f5e17febf3efe8d4ba1281dcc3aa0459ef424dc",
-                "sha256:7c2a1af393fcc09e898beba5dd59196edaa3116191cc7257f9224beaed3e1aa0",
-                "sha256:7d9884d86dd4dd489e981d94a65cd30d6f07203d90e98f6f657f05170f6324c9",
-                "sha256:90f11ff637fe8798933fb29f5ae1148c978cccb0452005bf4c69e13db951e765",
-                "sha256:919859aa909429fb5aa9cf8807f6045592c85ef56fdd30a9a3747e513db2536e",
-                "sha256:96fcd1888ab4d03adfc9303a7b3c0bd78c5412b2bfbe76db5b56d9eae004907a",
-                "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07",
-                "sha256:980d7be47c84979d9136328d882f67ec5e50008681d94ecc8afa8a65ed1f4a6f",
-                "sha256:a91aa8619b23b79bcbeb37abe286f2f408d2f2d6f29a17237afda55bb54e7aac",
-                "sha256:ade17eb5d643b7fead300a1641e9f45401c98eee23763e9ed66a43f92f20b4a7",
-                "sha256:b9c3db21af35e3b3c05764461b262d6f05bbca08a71a7849fd79d47ba7bc33ed",
-                "sha256:bd28bc2e3a772acbb07787c6308e00d9626ff89e3bfcdebe87fa5afbfdedf968",
-                "sha256:bf5824bfac591ddb2c1f0a5f4ab72da28994548c708d2191e3b87dd207eb3ad7",
-                "sha256:c0502c0fadef0d23b128605d69b58edb2c681c25d44574fc673b0e52dce71ee2",
-                "sha256:c38c71df845e2aabb7fb0b920d11a1b5ac8526005e533a8920aea97efb8ec6a4",
-                "sha256:ce15b6d103daff8e9fee13cf7f0add05245a05d866e73926c358e871221eae87",
-                "sha256:d3029c340cfbb3ac0a71798100ccc13b97dddf373a4ae56b6a72cf70dfd53bc8",
-                "sha256:e512d8ef5ad7b898cdb2d8ee1cb09a8339e4f8be706d27eaa180c2f177248a10",
-                "sha256:e8e5b509d5c2ff12f8418006d5a90e9436766133b564db0abaec92fd27fcee29",
-                "sha256:ee54ff27bf0afaf4c3b3a62bcd016c12c3fdb4ec4f413391a90bd38bc3624605",
-                "sha256:fa4537fb4a98fe8fde99626e4681cc644bdcf2a795038533f9f711513a862ae6",
-                "sha256:fd45ff9293d9274c5008a2054ecef86a9bfe819a67c7be1afb65e69b405b3042"
-            ],
-            "version": "==2021.4.4"
+            "version": "==2022.4"
         },
         "requests": {
             "hashes": [
-                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
-                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
-            "version": "==2.25.1"
+            "version": "==2.28.1"
+        },
+        "setuptools-dso": {
+            "hashes": [
+                "sha256:46f20b0ec32c3264e6d12e1d0347b80df50bb1dc94c825bea902763e1ea9e05f",
+                "sha256:67bd27feb2014a253ab026d2b2052c181e1e84fc602780e7fde746c45f602cf5"
+            ],
+            "version": "==2.5"
         },
         "snowballstemmer": {
             "hashes": [
-                "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2",
-                "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"
+                "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
+                "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"
             ],
-            "version": "==2.1.0"
+            "version": "==2.2.0"
         },
         "sphinx": {
             "hashes": [
-                "sha256:5747f3c855028076fcff1e4df5e75e07c836f0ac11f7df886747231092cfe4ad",
-                "sha256:dff357e6a208eb7edb2002714733ac21a9fe597e73609ff417ab8cf0c6b4fbb8"
+                "sha256:0a8836751a68306b3fe97ecbe44db786f8479c3bf4b80e3a7f5c838657b4698c",
+                "sha256:6a11ea5dd0bdb197f9c2abc2e0ce73e01340464feaece525e64036546d24c851"
             ],
-            "version": "==4.0.3"
+            "index": "pypi",
+            "version": "==4.3.2"
         },
         "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:32bd3b5d13dc8186d7a42fc816a23d32e83a4827d7d9882948e7b837c232da5a",
-                "sha256:4a05bdbe8b1446d77a01e20a23ebc6777c74f43237035e76be89699308987d6f"
+                "sha256:4d35a56f4508cfee4c4fb604373ede6feae2a306731d533f409ef5c3496fdbd8",
+                "sha256:eec6d497e4c2195fa0e8b2016b337532b8a699a68bcb22a512870e16925c6a5c"
             ],
             "index": "pypi",
-            "version": "==0.5.2"
+            "version": "==1.0.0"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -705,10 +847,10 @@
         },
         "sphinxcontrib-htmlhelp": {
             "hashes": [
-                "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f",
-                "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"
+                "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07",
+                "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"
             ],
-            "version": "==1.0.3"
+            "version": "==2.0.0"
         },
         "sphinxcontrib-jsmath": {
             "hashes": [
@@ -726,17 +868,10 @@
         },
         "sphinxcontrib-serializinghtml": {
             "hashes": [
-                "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc",
-                "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"
+                "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd",
+                "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"
             ],
-            "version": "==1.1.4"
-        },
-        "testfixtures": {
-            "hashes": [
-                "sha256:5ec3a0dd6f71cc4c304fbc024a10cc293d3e0b852c868014b9f233203e149bda",
-                "sha256:9ed31e83f59619e2fa17df053b241e16e0608f4580f7b5a9333a0c9bdcc99137"
-            ],
-            "version": "==6.17.1"
+            "version": "==1.1.5"
         },
         "toml": {
             "hashes": [
@@ -747,70 +882,70 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:056f0376bf5a6b182c513f9582c1e5b0487265eb6c48842b69aa9ca1cd5f640a",
-                "sha256:d60e681734099207a6add7a10326bc2ddd1fdc36c1b0f547d00ef73ac63739c2"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.2.0"
+            "version": "==2.0.1"
         },
         "typed-ast": {
             "hashes": [
-                "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace",
-                "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff",
-                "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266",
-                "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528",
-                "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6",
-                "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808",
-                "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4",
-                "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363",
-                "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341",
-                "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04",
-                "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41",
-                "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e",
-                "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3",
-                "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899",
-                "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805",
-                "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c",
-                "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c",
-                "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39",
-                "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a",
-                "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3",
-                "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7",
-                "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f",
-                "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075",
-                "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0",
-                "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40",
-                "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428",
-                "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927",
-                "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3",
-                "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
-                "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
+                "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2",
+                "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1",
+                "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6",
+                "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62",
+                "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac",
+                "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d",
+                "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc",
+                "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2",
+                "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97",
+                "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35",
+                "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6",
+                "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1",
+                "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4",
+                "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c",
+                "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e",
+                "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec",
+                "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f",
+                "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72",
+                "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47",
+                "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72",
+                "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe",
+                "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6",
+                "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3",
+                "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"
             ],
             "index": "pypi",
-            "version": "==1.4.3"
+            "version": "==1.5.4"
+        },
+        "types-mock": {
+            "hashes": [
+                "sha256:4535fbb3912b88a247d43cdb41db0c8b2e187138986f6f01a989717e56105848",
+                "sha256:a849bc2d966063f4946013bf404822ee2b96f77a8dccda4174b70ab61c5293fe"
+            ],
+            "index": "pypi",
+            "version": "==4.0.15"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
-                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
-                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
+                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
+                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
             ],
             "index": "pypi",
-            "version": "==3.10.0.0"
+            "version": "==4.4.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
-                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
+                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
-            "version": "==1.26.5"
+            "version": "==1.26.12"
         },
         "zipp": {
             "hashes": [
-                "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
-                "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"
+                "sha256:3a7af91c3db40ec72dd9d154ae18e008c69efe8ca88dde4f9a731bb82fe2f9eb",
+                "sha256:972cfa31bc2fedd3fa838a51e9bc7e64b7fb725a8c00e7431554311f180e9980"
             ],
-            "version": "==3.4.1"
+            "version": "==3.9.0"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "90a12d4253e1ffb0b319b61c579831e4d73b4fbcc5c7c46620e93199757dc1dd"
+            "sha256": "54f1fb92311a238c4813c2f415a8b69a3a4c5e070442535412f5e8d8a168f217"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -286,14 +286,6 @@
         }
     },
     "develop": {
-        "aioca": {
-            "hashes": [
-                "sha256:27f013040cfeb180b646f455134845a2f34c5a8a6aebac71e10c74b32055c4e9",
-                "sha256:7151aa5483191d17c02d13205ce4e42e4b2535bd78b73415943f8c7bbb6bc854"
-            ],
-            "index": "pypi",
-            "version": "==1.5.1"
-        },
         "alabaster": {
             "hashes": [
                 "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359",
@@ -437,39 +429,6 @@
                 "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"
             ],
             "version": "==0.17.1"
-        },
-        "epicscorelibs": {
-            "hashes": [
-                "sha256:05778faad8a5010708084e1047a15c46c1c44c19f9b3532d49480ff267cd59c9",
-                "sha256:0f07bddd3483f148b90b3351f6e5de6628fedb6e2262ccb219519731f81392b5",
-                "sha256:12d8f72efcfacfc785d5ad42bf0a5e76aac84f08f0f04570efa8a3fab132ae49",
-                "sha256:194155e170e7473fe8a6999489bd089e84a172955ec8db0d66155dc92a60c14c",
-                "sha256:22bef19a81de7b099b45dbbb8730c8aeb3e727f9e0609ba461835db35de75c9c",
-                "sha256:2e0d05a62c5fc0f126fc8e7924020c81257581d903255379e78720d7056a427c",
-                "sha256:3ab4ff529d8cd183f61d53a130b3ca4cf85b055bbc05b5607adfda3d10bb3674",
-                "sha256:415b98a44f75cb00563e47670bb8b233d0a47fde5bcf263deb828483062e9d99",
-                "sha256:48e1c63a0f5d06bb75a74f638fc10a31c87b5673708fda7ce1ec2e4319d33a17",
-                "sha256:4d06e2273ad4575e68278e64cac5ce4febea1e0110fc4a3aeec46c7a09fc71d2",
-                "sha256:5711e66be4bff06e198b3c90b9ee5b7e48017b4cc32c2245eb7e0581c889ff42",
-                "sha256:639e36fa63541d2a5903a3eda5fa1b832b94ed5c7131eeb68f02f07af56af3bb",
-                "sha256:68811552b3eae9f84c472a55775afcc13c66cb855207c08e19458a25d1b91765",
-                "sha256:76829079cda005ac1a8ad1231043199b1609bde3862e2ada92daf715d0aa6a5b",
-                "sha256:7d04129c2d1d3554a795f1c1fc97838999f198352b14854d16160c449879089a",
-                "sha256:8fdb1648f7873083a41b466d0428bc4076c6b73772bfab17a5b1a19011f7f8ef",
-                "sha256:9fd10d3f1fefd96f2b0751f65fa44791b978521b4a020cb5105cdbd80a0fcf84",
-                "sha256:a3e8a8482334087554f143f9cacb3393850378249196c2c53c8335bf44cf7a23",
-                "sha256:bbc444b4835c9742e40b94a1c590f1841453c40d51add8ce3a76599a0c02534a",
-                "sha256:be4dfa2518d336341162a217708ca18451b54db59b54c7685357d11efa00baac",
-                "sha256:c2aad6b3068a1dc9ccfd6bdc38886bd1ffa0bd96a429f3f05c1b97b2363095fa",
-                "sha256:c8060993f7628c9b445b6bb2080cf5fef8869e6e9fbd75398756f5b910528dda",
-                "sha256:d08cd4b228d7087fd172b9b48d5ebc1c763b6c1fbda26369776d5b274f1c73b4",
-                "sha256:d42a4342cbdb2c6452b6482f0e59a5043ca0c4c41ac6d48d1cb382c0257f9b85",
-                "sha256:dda6066046096aeb23c7fa7f7bef519316a8eb1f6e46b0859cdc614c03054d08",
-                "sha256:e277d538c531407f4926f8bfe4d06389b2a3fff9671000e11f2f2aa10cadce41",
-                "sha256:ebade58f5430ee2a597b56080cfff800389016c02aa33f394f2796d73e5d52d4",
-                "sha256:f136ef89acc19bb855f53ad29a768ecfbafcc22bd355eec8c17164c2735c5ecc"
-            ],
-            "version": "==7.0.7.99.0.0"
         },
         "filelock": {
             "hashes": [
@@ -641,43 +600,6 @@
             ],
             "version": "==0.4.3"
         },
-        "numpy": {
-            "hashes": [
-                "sha256:1dbe1c91269f880e364526649a52eff93ac30035507ae980d2fed33aaee633ac",
-                "sha256:357768c2e4451ac241465157a3e929b265dfac85d9214074985b1786244f2ef3",
-                "sha256:3820724272f9913b597ccd13a467cc492a0da6b05df26ea09e78b171a0bb9da6",
-                "sha256:4391bd07606be175aafd267ef9bea87cf1b8210c787666ce82073b05f202add1",
-                "sha256:4aa48afdce4660b0076a00d80afa54e8a97cd49f457d68a4342d188a09451c1a",
-                "sha256:58459d3bad03343ac4b1b42ed14d571b8743dc80ccbf27444f266729df1d6f5b",
-                "sha256:5c3c8def4230e1b959671eb959083661b4a0d2e9af93ee339c7dada6759a9470",
-                "sha256:5f30427731561ce75d7048ac254dbe47a2ba576229250fb60f0fb74db96501a1",
-                "sha256:643843bcc1c50526b3a71cd2ee561cf0d8773f062c8cbaf9ffac9fdf573f83ab",
-                "sha256:67c261d6c0a9981820c3a149d255a76918278a6b03b6a036800359aba1256d46",
-                "sha256:67f21981ba2f9d7ba9ade60c9e8cbaa8cf8e9ae51673934480e45cf55e953673",
-                "sha256:6aaf96c7f8cebc220cdfc03f1d5a31952f027dda050e5a703a0d1c396075e3e7",
-                "sha256:7c4068a8c44014b2d55f3c3f574c376b2494ca9cc73d2f1bd692382b6dffe3db",
-                "sha256:7c7e5fa88d9ff656e067876e4736379cc962d185d5cd808014a8a928d529ef4e",
-                "sha256:7f5ae4f304257569ef3b948810816bc87c9146e8c446053539947eedeaa32786",
-                "sha256:82691fda7c3f77c90e62da69ae60b5ac08e87e775b09813559f8901a88266552",
-                "sha256:8737609c3bbdd48e380d463134a35ffad3b22dc56295eff6f79fd85bd0eeeb25",
-                "sha256:9f411b2c3f3d76bba0865b35a425157c5dcf54937f82bbeb3d3c180789dd66a6",
-                "sha256:a6be4cb0ef3b8c9250c19cc122267263093eee7edd4e3fa75395dfda8c17a8e2",
-                "sha256:bcb238c9c96c00d3085b264e5c1a1207672577b93fa666c3b14a45240b14123a",
-                "sha256:bf2ec4b75d0e9356edea834d1de42b31fe11f726a81dfb2c2112bc1eaa508fcf",
-                "sha256:d136337ae3cc69aa5e447e78d8e1514be8c3ec9b54264e680cf0b4bd9011574f",
-                "sha256:d4bf4d43077db55589ffc9009c0ba0a94fa4908b9586d6ccce2e0b164c86303c",
-                "sha256:d6a96eef20f639e6a97d23e57dd0c1b1069a7b4fd7027482a4c5c451cd7732f4",
-                "sha256:d9caa9d5e682102453d96a0ee10c7241b72859b01a941a397fd965f23b3e016b",
-                "sha256:dd1c8f6bd65d07d3810b90d02eba7997e32abbdf1277a481d698969e921a3be0",
-                "sha256:e31f0bb5928b793169b87e3d1e070f2342b22d5245c755e2b81caa29756246c3",
-                "sha256:ecb55251139706669fdec2ff073c98ef8e9a84473e51e716211b41aa0f18e656",
-                "sha256:ee5ec40fdd06d62fe5d4084bef4fd50fd4bb6bfd2bf519365f569dc470163ab0",
-                "sha256:f17e562de9edf691a42ddb1eb4a5541c20dd3f9e65b09ded2beb0799c0cf29bb",
-                "sha256:fdffbfb6832cd0b300995a2b08b8f6fa9f6e856d562800fea9182316d99c4e8e"
-            ],
-            "index": "pypi",
-            "version": "==1.21.6"
-        },
         "packaging": {
             "hashes": [
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
@@ -800,13 +722,6 @@
                 "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
             "version": "==2.28.1"
-        },
-        "setuptools-dso": {
-            "hashes": [
-                "sha256:46f20b0ec32c3264e6d12e1d0347b80df50bb1dc94c825bea902763e1ea9e05f",
-                "sha256:67bd27feb2014a253ab026d2b2052c181e1e84fc602780e7fde746c45f602cf5"
-            ],
-            "version": "==2.5"
         },
         "snowballstemmer": {
             "hashes": [

--- a/pandablocks/_control.py
+++ b/pandablocks/_control.py
@@ -49,7 +49,7 @@ class BlockCompleter:
 
     def _get_fields(self, blocks: List[str]) -> Dict[str, Dict[str, FieldInfo]]:
         fields = self._client.send(
-            [GetFieldInfo(block, skip_description=True) for block in blocks],
+            [GetFieldInfo(block, extended_metadata=False) for block in blocks],
             timeout=TIMEOUT,
         )
         return dict(zip(blocks, fields))

--- a/pandablocks/commands.py
+++ b/pandablocks/commands.py
@@ -271,24 +271,22 @@ class Put(Command[None]):
 
     Args:
         field: The field, attribute, or star command to put
-        value: The value, either str multiline or None, to put
+        value: The value, either string or list of strings or empty, to put
 
     For example::
 
         Put("PCAP.TRIG", "PULSE1.OUT")
         Put("SEQ1.TABLE", ["1048576", "0", "1000", "1000"])
-        Put("SFP3_SYNC_IN1.SYNC_RESET", None)
+        Put("SFP3_SYNC_IN1.SYNC_RESET")
     """
 
     field: str
-    value: Union[str, List[str], None] = ""
+    value: Union[str, List[str]] = ""
 
     def execute(self) -> ExchangeGenerator[None]:
         if isinstance(self.value, list):
             # Multiline table with blank line to terminate
             ex = Exchange([f"{self.field}<"] + self.value + [""])
-        elif self.value is None:
-            ex = Exchange(f"{self.field}=")
         else:
             ex = Exchange(f"{self.field}={self.value}")
         yield ex

--- a/pandablocks/connections.py
+++ b/pandablocks/connections.py
@@ -148,7 +148,7 @@ class ControlConnection:
                 do_something_with(response)
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._buf = Buffer()
         self._lines: List[str] = []
         self._contexts: Deque[_ExchangeContext] = deque()
@@ -263,7 +263,7 @@ class DataConnection:
                 do_something_with(data)
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # TODO: could support big endian, but are there any systems out there?
         assert sys.byteorder == "little", "PandA sends data little endian"
         # Store of bytes received so far to parse in the handlers
@@ -271,7 +271,7 @@ class DataConnection:
         # Header text from PandA with field info
         self._header = ""
         # The next parsing handler that should be called if there is data in buffer
-        self._next_handler: Callable[[], Optional[Iterator[Data]]] = None
+        self._next_handler: Optional[Callable[[], Optional[Iterator[Data]]]] = None
         # numpy dtype of produced FrameData
         self._frame_dtype = None
         # frame data that has been received but should be discarded on Data Overrun

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ packages = find:
 install_requires =
     numpy
     click
+    importlib-metadata <5.0 # 5.0 deprecated a lot of interfaces that various modules rely on
 
 [options.extras_require]
 hdf5 =
@@ -60,6 +61,9 @@ extend-ignore =
 addopts =
     --tb=native -vv --flake8 --black --mypy --doctest-modules --doctest-glob="*.rst"
      --cov=pandablocks --cov-report term --cov-report xml:cov.xml
+# Enables all discovered async tests and fixtures to be automatically marked as async, even if
+# they don't have a specific marker https://github.com/pytest-dev/pytest-asyncio#auto-mode
+asyncio_mode = auto
 
 [coverage:run]
 # This is covered in the versiongit test suite so exclude it here

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1,20 +1,16 @@
-import pytest
+import pytest_asyncio
 
 from pandablocks._control import BlockCompleter
 from pandablocks.blocking import BlockingClient
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 def dummy_server_with_blocks(dummy_server_in_thread):
     dummy_server_in_thread.send += [
         "!PCAP 1\n!LUT 8\n!SRGATE 2\n.",
         "!INPB 1 bit_mux\n!TYPEA 5 param enum\n.",  # LUT fields
         "!TRIG_EDGE 3 param enum\n!GATE 1 bit_mux\n.",  # PCAP fields
         "!OUT 1 bit_out\n.",  # SRGATE fields
-        "!TTLIN1.VAL\n!LVDSIN1.VAL\n.",  # LUT.INPB labels
-        "!Input-Level\n!Pulse-On-Rising-Edge\n.",  # LUT.TYPEA labels
-        "!TTLIN1.VAL\n!LVDSIN1.VAL\n.",  # PCAP.GATE labels
-        "!Rising\n!Falling\n.",  # PCAP.TRIG_EDGE labels
     ]
     yield dummy_server_in_thread
 

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -180,10 +180,10 @@ def test_connect_put_multi_line_bad_list_format():
         assert conn.send(cmd) == b""
 
 
-def test_connect_put_none_value():
-    """Confirm Put works with a value of None"""
+def test_connect_put_no_value():
+    """Confirm Put works with no value"""
     conn = ControlConnection()
-    cmd = Put("SFP3_SYNC_IN1.SYNC_RESET", None)
+    cmd = Put("SFP3_SYNC_IN1.SYNC_RESET")
     assert conn.send(cmd) == b"SFP3_SYNC_IN1.SYNC_RESET=\n"
     assert get_responses(conn, b"OK\n") == [(cmd, None)]
 

--- a/tests/test_pandablocks.py
+++ b/tests/test_pandablocks.py
@@ -3,11 +3,14 @@ from typing import Iterator, OrderedDict
 import pytest
 
 from pandablocks.commands import (
+    ChangeGroup,
     CommandException,
-    FieldInfo,
     Get,
     GetBlockInfo,
+    GetChanges,
     GetFieldInfo,
+    GetLine,
+    GetMultiline,
     GetPcapBitsLabels,
     GetState,
     Put,
@@ -19,7 +22,25 @@ from pandablocks.connections import (
     DataConnection,
     NoContextAvailable,
 )
-from pandablocks.responses import BlockInfo, Data
+from pandablocks.responses import (
+    BitMuxFieldInfo,
+    BitOutFieldInfo,
+    BlockInfo,
+    Changes,
+    Data,
+    EnumFieldInfo,
+    ExtOutBitsFieldInfo,
+    ExtOutFieldInfo,
+    FieldInfo,
+    PosMuxFieldInfo,
+    PosOutFieldInfo,
+    ScalarFieldInfo,
+    SubtypeTimeFieldInfo,
+    TableFieldDetails,
+    TableFieldInfo,
+    TimeFieldInfo,
+    UintFieldInfo,
+)
 from tests.conftest import STATE_RESPONSES, STATE_SAVEFILE
 
 
@@ -43,6 +64,59 @@ def test_connection_gets_muliline():
     assert not get_responses(conn, b"!1048576\n!0\n!10")
     assert get_responses(conn, b"00\n!1000\n.\n") == [
         (cmd, ["1048576", "0", "1000", "1000"])
+    ]
+
+
+def test_get_line():
+    conn = ControlConnection()
+    cmd = GetLine("PCAP.ACTIVE")
+    assert conn.send(cmd) == b"PCAP.ACTIVE?\n"
+    assert get_responses(conn, b"OK =1\n") == [(cmd, "1")]
+
+
+def test_get_line_error_when_multiline():
+    conn = ControlConnection()
+    cmd = GetLine("PCAP.ACTIVE")
+    assert conn.send(cmd) == b"PCAP.ACTIVE?\n"
+    assert get_responses(conn, b"!ACTIVE 5 bit_out\n.\n") == [
+        (
+            cmd,
+            ACommandException("GetLine(field='PCAP.ACTIVE') ->\n    ACTIVE 5 bit_out"),
+        )
+    ]
+
+
+def test_get_line_error_no_ok():
+    conn = ControlConnection()
+    cmd = GetLine("PCAP.ACTIVE")
+    assert conn.send(cmd) == b"PCAP.ACTIVE?\n"
+    assert get_responses(conn, b"NOT OK\n") == [
+        (
+            cmd,
+            ACommandException("GetLine(field='PCAP.ACTIVE') -> NOT OK"),
+        )
+    ]
+
+
+def test_get_multiline():
+    conn = ControlConnection()
+    cmd = GetMultiline("PCAP.*")
+    assert conn.send(cmd) == b"PCAP.*?\n"
+    assert get_responses(conn, b"!ACTIVE 5 bit_out\n.\n") == [
+        (cmd, ["ACTIVE 5 bit_out"])
+    ]
+
+
+def test_get_multiline_error_when_single_line():
+    conn = ControlConnection()
+    cmd = GetMultiline("PCAP.*")
+    assert conn.send(cmd) == b"PCAP.*?\n"
+
+    assert get_responses(conn, b"1\n") == [
+        (
+            cmd,
+            ACommandException("GetMultiline(field='PCAP.*') -> 1"),
+        )
     ]
 
 
@@ -95,6 +169,22 @@ def test_connect_put_multi_line():
     conn = ControlConnection()
     cmd = Put("SEQ1.TABLE", ["1048576", "0", "1000", "1000"])
     assert conn.send(cmd) == b"SEQ1.TABLE<\n1048576\n0\n1000\n1000\n\n"
+    assert get_responses(conn, b"OK\n") == [(cmd, None)]
+
+
+def test_connect_put_multi_line_bad_list_format():
+    """Confirm that an invalid data format raises the expected exception"""
+    conn = ControlConnection()
+    cmd = Put("SEQ1.TABLE", [1, 2, 3])
+    with pytest.raises(TypeError):
+        assert conn.send(cmd) == b""
+
+
+def test_connect_put_none_value():
+    """Confirm Put works with a value of None"""
+    conn = ControlConnection()
+    cmd = Put("SFP3_SYNC_IN1.SYNC_RESET", None)
+    assert conn.send(cmd) == b"SFP3_SYNC_IN1.SYNC_RESET=\n"
     assert get_responses(conn, b"OK\n") == [(cmd, None)]
 
 
@@ -191,6 +281,7 @@ def test_get_block_info_desc_err():
 
 
 def test_get_fields():
+    """Simple test case for GetFieldInfo"""
     conn = ControlConnection()
     cmd = GetFieldInfo("LUT")
     assert conn.send(cmd) == b"LUT.*?\n"
@@ -198,15 +289,17 @@ def test_get_fields():
     # First yield, the response to "LUT.*?"
     assert (
         conn.receive_bytes(b"!TYPEA 5 param enum\n!INPA 1 bit_mux\n.\n")
-        == b"*DESC.LUT.INPA?\n*ENUMS.LUT.INPA?\n*DESC.LUT.TYPEA?\n*ENUMS.LUT.TYPEA?\n"
+        == b"*DESC.LUT.TYPEA?\n*ENUMS.LUT.TYPEA?\n*DESC.LUT.INPA?\n"
+        + b"LUT1.INPA.MAX_DELAY?\n*ENUMS.LUT.INPA?\n"
     )
 
-    # Responses to the 2 *DESC and 2 *ENUM commands
+    # Responses to the 2 *DESC, 2 *ENUM, and MAX_DELAY commands
     responses = [
-        b"OK =Input A\n",
-        b"!TTLIN1.VAL\n!LVDSIN1.VAL\n.\n"
         b"OK =Source of the value of A for calculation\n",
         b"!Input-Level\n!Pulse-On-Rising-Edge\n.\n",
+        b"OK =Input A\n",
+        b"OK =10\n",
+        b"!TTLIN1.VAL\n!LVDSIN1.VAL\n.\n",
     ]
     for response in responses:
         assert (
@@ -217,13 +310,14 @@ def test_get_fields():
         (
             cmd,
             {
-                "INPA": FieldInfo(
+                "INPA": BitMuxFieldInfo(
                     type="bit_mux",
                     subtype=None,
                     description="Input A",
                     labels=["TTLIN1.VAL", "LVDSIN1.VAL"],
+                    max_delay=10,
                 ),
-                "TYPEA": FieldInfo(
+                "TYPEA": EnumFieldInfo(
                     type="param",
                     subtype="enum",
                     description="Source of the value of A for calculation",
@@ -261,48 +355,36 @@ def test_get_fields_type_ext_out():
         (
             cmd,
             {
-                "SAMPLES": FieldInfo(
+                "SAMPLES": ExtOutFieldInfo(
                     type="ext_out",
                     subtype="samples",
                     description="Number of gated samples in the current capture",
-                    labels=["No", "Value"],
+                    capture_labels=["No", "Value"],
                 )
             },
         )
     ]
 
 
-def test_get_fields_type_skip_description():
-    """Test that the skip_description flag causes no description to be retrieved
+def test_get_fields_skip_metadata():
+    """Test that the skip_metadata flag causes no description to be retrieved
     for the field"""
     conn = ControlConnection()
-    cmd = GetFieldInfo("PCAP", True)
+    cmd = GetFieldInfo("PCAP", False)
     assert conn.send(cmd) == b"PCAP.*?\n"
 
-    assert (
-        conn.receive_bytes(b"!SAMPLES 9 ext_out samples\n.\n")
-        == b"*ENUMS.PCAP.SAMPLES.CAPTURE?\n"
-    )
-
-    assert conn.receive_bytes(b"!No\n!Value\n.\n") == b""
+    assert conn.receive_bytes(b"!SAMPLES 9 ext_out samples\n.\n") == b""
 
     assert get_responses(conn) == [
         (
             cmd,
-            {
-                "SAMPLES": FieldInfo(
-                    type="ext_out",
-                    subtype="samples",
-                    description=None,
-                    labels=["No", "Value"],
-                )
-            },
+            {"SAMPLES": FieldInfo(type="ext_out", subtype="samples", description=None)},
         )
     ]
 
 
-def test_get_fields_non_existant_field():
-    """Test that querying for an unknown field returns a sensible error"""
+def test_get_fields_non_existant_block():
+    """Test that querying for an unknown block returns a sensible error"""
     conn = ControlConnection()
     cmd = GetFieldInfo("FOO")
     assert conn.send(cmd) == b"FOO.*?\n"
@@ -314,54 +396,560 @@ def test_get_fields_non_existant_field():
         (
             cmd,
             ACommandException(
-                "GetFieldInfo(block='FOO', skip_description=False) -> ERR No such block"
+                "GetFieldInfo(block='FOO', extended_metadata=True) -> ERR No such block"
             ),
         )
     ]
 
 
-def test_get_fields_no_enums():
-    """Test that a field that does not have any enum labels does not attempt to
-    retrieve them"""
+def test_get_fields_unknown_fields():
+    """Test that querying for an unknown field and/or subtype still tries to request a
+    description"""
     conn = ControlConnection()
-    cmd = GetFieldInfo("LVDSIN")
-    assert conn.send(cmd) == b"LVDSIN.*?\n"
+    cmd = GetFieldInfo("PCAP")
+    assert conn.send(cmd) == b"PCAP.*?\n"
 
-    # First yield, the response to "LVDSIN.*?"
-    assert conn.receive_bytes(b"!VAL 0 bit_out\n.\n") == b"*DESC.LVDSIN.VAL?\n"
+    # TEST1 has unknown field name, TEST2 has both unknown field and subtype name,
+    # TEST3 has known field name but unknown subtype, TEST4 has unknown type but known
+    # subtype
+    assert (
+        conn.receive_bytes(
+            b"!TEST1 1 foo\n!TEST2 2 flibble bibble\n!TEST3 3 param unknown\n"
+            + b"!TEST4 4 fish uint\n.\n"
+        )
+        == b"*DESC.PCAP.TEST1?\n*DESC.PCAP.TEST2?\n*DESC.PCAP.TEST3?\n"
+        + b"*DESC.PCAP.TEST4?\n"
+    )
 
-    assert get_responses(conn, b"OK =LVDS input value\n") == [
+    responses = [
+        b"OK =TEST1 Desc\n",
+        b"OK =TEST2 Desc\n",
+        b"OK =TEST3 Desc\n",
+        b"OK =TEST4 Desc\n",
+    ]
+
+    for response in responses:
+        assert conn.receive_bytes(response) == b""
+
+    assert get_responses(conn) == [
         (
             cmd,
             {
-                "VAL": FieldInfo(
-                    type="bit_out",
-                    subtype=None,
-                    description="LVDS input value",
-                    labels=None,
+                "TEST1": FieldInfo(type="foo", subtype=None, description="TEST1 Desc"),
+                "TEST2": FieldInfo(
+                    type="flibble", subtype="bibble", description="TEST2 Desc"
+                ),
+                "TEST3": FieldInfo(
+                    type="param", subtype="unknown", description="TEST3 Desc"
+                ),
+                "TEST4": FieldInfo(
+                    type="fish", subtype="uint", description="TEST4 Desc"
                 ),
             },
+        ),
+    ]
+
+
+def idfn(val):
+    """helper function to nicely name parameterized test IDs"""
+    if isinstance(val, str):
+        if val.count("?\n") > 0:
+            return ""
+        return val
+    else:
+        return ""
+
+
+# Table field handled in separate test due to extra round of network calls required
+@pytest.mark.parametrize(
+    "field_type, field_subtype, requests_responses, expected_field_info",
+    [
+        (
+            "param",
+            "uint",
+            [
+                ("TEST1.TEST_FIELD.MAX?", "OK =10"),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            UintFieldInfo("param", "uint", max_val=10, description="Test Description"),
+        ),
+        (
+            "read",
+            "uint",
+            [
+                ("TEST1.TEST_FIELD.MAX?", "OK =67"),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            UintFieldInfo("read", "uint", max_val=67, description="Test Description"),
+        ),
+        (
+            "write",
+            "uint",
+            [
+                ("TEST1.TEST_FIELD.MAX?", "OK =58"),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            UintFieldInfo("write", "uint", max_val=58, description="Test Description"),
+        ),
+        (
+            "param",
+            "int",
+            [
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            FieldInfo("param", "int", description="Test Description"),
+        ),
+        (
+            "read",
+            "int",
+            [
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            FieldInfo("read", "int", description="Test Description"),
+        ),
+        (
+            "write",
+            "int",
+            [
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            FieldInfo("write", "int", description="Test Description"),
+        ),
+        (
+            "param",
+            "scalar",
+            [
+                ("TEST.TEST_FIELD.UNITS?", "OK =some_units"),
+                ("TEST.TEST_FIELD.SCALE?", "OK =0.5"),
+                ("TEST.TEST_FIELD.OFFSET?", "OK =8"),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            ScalarFieldInfo(
+                "param",
+                "scalar",
+                units="some_units",
+                scale=0.5,
+                offset=8,
+                description="Test Description",
+            ),
+        ),
+        (
+            "read",
+            "scalar",
+            [
+                ("TEST.TEST_FIELD.UNITS?", "OK =some_units"),
+                ("TEST.TEST_FIELD.SCALE?", "OK =0.5"),
+                ("TEST.TEST_FIELD.OFFSET?", "OK =8"),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            ScalarFieldInfo(
+                "read",
+                "scalar",
+                units="some_units",
+                scale=0.5,
+                offset=8,
+                description="Test Description",
+            ),
+        ),
+        (
+            "write",
+            "scalar",
+            [
+                ("TEST.TEST_FIELD.UNITS?", "OK =some_units"),
+                ("TEST.TEST_FIELD.SCALE?", "OK =0.5"),
+                ("TEST.TEST_FIELD.OFFSET?", "OK =8"),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            ScalarFieldInfo(
+                "write",
+                "scalar",
+                units="some_units",
+                scale=0.5,
+                offset=8,
+                description="Test Description",
+            ),
+        ),
+        (
+            "param",
+            "bit",
+            [
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            FieldInfo("param", "bit", description="Test Description"),
+        ),
+        (
+            "read",
+            "bit",
+            [
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            FieldInfo("read", "bit", description="Test Description"),
+        ),
+        (
+            "read",
+            "bit",
+            [
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            FieldInfo("read", "bit", description="Test Description"),
+        ),
+        (
+            "param",
+            "action",
+            [
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            FieldInfo("param", "action", description="Test Description"),
+        ),
+        (
+            "read",
+            "action",
+            [
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            FieldInfo("read", "action", description="Test Description"),
+        ),
+        (
+            "write",
+            "action",
+            [
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            FieldInfo("write", "action", description="Test Description"),
+        ),
+        (
+            "param",
+            "lut",
+            [
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            FieldInfo("param", "lut", description="Test Description"),
+        ),
+        (
+            "read",
+            "lut",
+            [
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            FieldInfo("read", "lut", description="Test Description"),
+        ),
+        (
+            "write",
+            "lut",
+            [
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            FieldInfo("write", "lut", description="Test Description"),
+        ),
+        (
+            "param",
+            "enum",
+            [
+                ("*ENUMS.TEST.TEST_FIELD?", "!VAL1\n!VAL2\n."),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            EnumFieldInfo(
+                "param", "enum", labels=["VAL1", "VAL2"], description="Test Description"
+            ),
+        ),
+        (
+            "read",
+            "enum",
+            [
+                ("*ENUMS.TEST.TEST_FIELD?", "!VAL1\n!VAL2\n."),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            EnumFieldInfo(
+                "read", "enum", labels=["VAL1", "VAL2"], description="Test Description"
+            ),
+        ),
+        (
+            "write",
+            "enum",
+            [
+                ("*ENUMS.TEST.TEST_FIELD?", "!VAL1\n!VAL2\n."),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            EnumFieldInfo(
+                "write", "enum", labels=["VAL1", "VAL2"], description="Test Description"
+            ),
+        ),
+        (
+            "param",
+            "time",
+            [
+                ("*ENUMS.TEST.TEST_FIELD.UNITS?", "!VAL1\n!VAL2\n."),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            SubtypeTimeFieldInfo(
+                "param",
+                "time",
+                units_labels=["VAL1", "VAL2"],
+                description="Test Description",
+            ),
+        ),
+        (
+            "read",
+            "time",
+            [
+                ("*ENUMS.TEST.TEST_FIELD.UNITS?", "!VAL1\n!VAL2\n."),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            SubtypeTimeFieldInfo(
+                "read",
+                "time",
+                units_labels=["VAL1", "VAL2"],
+                description="Test Description",
+            ),
+        ),
+        (
+            "write",
+            "time",
+            [
+                ("*ENUMS.TEST.TEST_FIELD.UNITS?", "!VAL1\n!VAL2\n."),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            SubtypeTimeFieldInfo(
+                "write",
+                "time",
+                units_labels=["VAL1", "VAL2"],
+                description="Test Description",
+            ),
+        ),
+        (
+            "time",
+            None,
+            [
+                ("*ENUMS.TEST.TEST_FIELD.UNITS?", "!VAL1\n!VAL2\n."),
+                ("TEST1.TEST_FIELD.MIN?", "OK =5e-8"),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            TimeFieldInfo(
+                "time",
+                None,
+                units_labels=["VAL1", "VAL2"],
+                min_val=5e-8,
+                description="Test Description",
+            ),
+        ),
+        (
+            "bit_out",
+            None,
+            [
+                ("TEST1.TEST_FIELD.CAPTURE_WORD?", "OK =PCAP.BITS1"),
+                ("TEST1.TEST_FIELD.OFFSET?", "OK =12"),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            BitOutFieldInfo(
+                "bit_out",
+                None,
+                capture_word="PCAP.BITS1",
+                offset=12,
+                description="Test Description",
+            ),
+        ),
+        (
+            "pos_out",
+            None,
+            [
+                ("*ENUMS.TEST.TEST_FIELD.CAPTURE?", "!VAL1\n!VAL2\n."),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            PosOutFieldInfo(
+                "pos_out",
+                None,
+                capture_labels=["VAL1", "VAL2"],
+                description="Test Description",
+            ),
+        ),
+        (
+            "ext_out",
+            "timestamp",
+            [
+                ("*ENUMS.TEST.TEST_FIELD.CAPTURE?", "!VAL1\n!VAL2\n."),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            ExtOutFieldInfo(
+                "ext_out",
+                "timestamp",
+                capture_labels=["VAL1", "VAL2"],
+                description="Test Description",
+            ),
+        ),
+        (
+            "ext_out",
+            "samples",
+            [
+                ("*ENUMS.TEST.TEST_FIELD.CAPTURE?", "!VAL1\n!VAL2\n."),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            ExtOutFieldInfo(
+                "ext_out",
+                "samples",
+                capture_labels=["VAL1", "VAL2"],
+                description="Test Description",
+            ),
+        ),
+        (
+            "ext_out",
+            "bits",
+            [
+                ("TEST.TEST_FIELD.BITS?", "!BITS1\n!BITS2\n."),
+                ("*ENUMS.TEST.TEST_FIELD.CAPTURE?", "!VAL1\n!VAL2\n."),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            ExtOutBitsFieldInfo(
+                "ext_out",
+                "bits",
+                bits=["BITS1", "BITS2"],
+                capture_labels=["VAL1", "VAL2"],
+                description="Test Description",
+            ),
+        ),
+        (
+            "bit_mux",
+            None,
+            [
+                ("TEST1.TEST_FIELD.MAX_DELAY?", "OK =25"),
+                ("*ENUMS.TEST.TEST_FIELD?", "!VAL1\n!VAL2\n."),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            BitMuxFieldInfo(
+                "bit_mux",
+                None,
+                max_delay=25,
+                labels=["VAL1", "VAL2"],
+                description="Test Description",
+            ),
+        ),
+        (
+            "pos_mux",
+            None,
+            [
+                ("*ENUMS.TEST.TEST_FIELD?", "!VAL1\n!VAL2\n."),
+                ("*DESC.TEST.TEST_FIELD?", "OK =Test Description"),
+            ],
+            PosMuxFieldInfo(
+                "pos_mux",
+                None,
+                labels=["VAL1", "VAL2"],
+                description="Test Description",
+            ),
+        ),
+    ],
+    ids=idfn,
+)
+def test_get_fields_parameterized_type(
+    field_type, field_subtype, requests_responses, expected_field_info
+):
+    """Test every defined field type-subtype pair that has a defined function
+    and confirm it creates the expected FieldInfo (or subclass) with the expected
+    data"""
+    conn = ControlConnection()
+    cmd = GetFieldInfo("TEST", extended_metadata=True)
+    assert conn.send(cmd) == b"TEST.*?\n"
+
+    if field_subtype is None:
+        field_subtype = ""  # Ensure we don't write the literal string "None"
+
+    field_definition_str = f"!TEST_FIELD 1 {field_type} {field_subtype}\n.\n"
+
+    # Split to get individual requests in a list - we don't care about the order
+    received_bytes = conn.receive_bytes(field_definition_str.encode())
+    received_requests_list = received_bytes.decode().splitlines()
+
+    expected_requests = [x[0] for x in requests_responses]
+    responses = [x[1] for x in requests_responses]
+
+    for request in received_requests_list:
+        idx = expected_requests.index(request)
+        response = responses[idx] + "\n"
+        assert conn.receive_bytes(response.encode()) == b""
+        expected_requests.pop(idx)
+        responses.pop(idx)
+
+    assert (
+        not expected_requests
+    ), f"Did not receive all expected requests: {expected_requests}"
+
+    assert get_responses(conn) == [
+        (
+            cmd,
+            {"TEST_FIELD": expected_field_info},
         )
     ]
 
 
-def test_get_fields_no_enums_no_description():
-    """Test that a field that does not have any enum labels does not attempt to
-    retrieve them, and also does not retrieve a description."""
+def test_get_fields_type_table():
+    """Test for table field type, including descriptions and retrieving enum labels"""
     conn = ControlConnection()
-    cmd = GetFieldInfo("LVDSIN", skip_description=True)
-    assert conn.send(cmd) == b"LVDSIN.*?\n"
+    cmd = GetFieldInfo("SEQ")
+    assert conn.send(cmd) == b"SEQ.*?\n"
 
-    assert get_responses(conn, b"!VAL 0 bit_out\n.\n") == [
+    assert (
+        conn.receive_bytes(b"!TABLE 7 table\n.\n")
+        == b"*DESC.SEQ.TABLE?\nSEQ1.TABLE.MAX_LENGTH?\nSEQ1.TABLE.FIELDS?\n"
+    )
+
+    assert conn.receive_bytes(b"OK =Sequencer table of lines\n") == b""
+
+    assert conn.receive_bytes(b"OK =16384\n") == b""
+
+    assert (
+        conn.receive_bytes(
+            b"!15:0 REPEATS uint\n!19:16 TRIGGER enum\n!63:32 POSITION int\n.\n"
+        )
+        == b"*ENUMS.SEQ1.TABLE[].TRIGGER?\n*DESC.SEQ1.TABLE[].REPEATS?\n"
+        b"*DESC.SEQ1.TABLE[].TRIGGER?\n*DESC.SEQ1.TABLE[].POSITION?\n"
+    )
+
+    responses = [
+        b"!Immediate\n!BITA=0\n.\n",
+        b"OK =Number of times the line will repeat\n",
+        b"OK =The trigger condition to start the phases\n",
+        b"OK =The position that can be used in trigger condition\n",
+    ]
+    for response in responses:
+        assert (
+            conn.receive_bytes(response) == b""
+        )  # Expect no bytes back as none of these trigger further commands
+
+    assert get_responses(conn) == [
         (
             cmd,
             {
-                "VAL": FieldInfo(
-                    type="bit_out",
+                "TABLE": TableFieldInfo(
+                    type="table",
                     subtype=None,
-                    description=None,
-                    labels=None,
-                ),
+                    description="Sequencer table of lines",
+                    max_length=16384,
+                    row_words=2,  # Calculated from POSITION field's highest used bit
+                    fields={
+                        "REPEATS": TableFieldDetails(
+                            subtype="uint",
+                            bit_low=0,
+                            bit_high=15,
+                            description="Number of times the line will repeat",
+                            labels=None,
+                        ),
+                        "TRIGGER": TableFieldDetails(
+                            subtype="enum",
+                            bit_low=16,
+                            bit_high=19,
+                            description="The trigger condition to start the phases",
+                            labels=["Immediate", "BITA=0"],
+                        ),
+                        "POSITION": TableFieldDetails(
+                            subtype="int",
+                            bit_low=32,
+                            bit_high=63,
+                            description=(
+                                "The position that can be used in trigger condition"
+                            ),
+                            labels=None,
+                        ),
+                    },
+                )
             },
         )
     ]
@@ -454,6 +1042,165 @@ def test_expected_exception_when_receive_without_send():
     conn = ControlConnection()
     with pytest.raises(NoContextAvailable):
         conn.receive_bytes(b"abc\n")
+
+
+def test_get_changes_values():
+    """Test that the `values` field returned from `GetChanges` is correctly populated"""
+    conn = ControlConnection()
+    cmd = GetChanges()
+
+    assert conn.send(cmd) == b"*CHANGES?\n"
+
+    assert conn.receive_bytes(b"!Field 1=Value1\n!Field2=Other Value\n.\n") == b""
+
+    assert get_responses(conn) == [
+        (
+            cmd,
+            Changes(
+                values={"Field 1": "Value1", "Field2": "Other Value"},
+                no_value=[],
+                in_error=[],
+                multiline_values={},
+            ),
+        )
+    ]
+
+
+def test_get_changes_values_empty():
+    """Test that the `values` field returned from `GetChanges` is correctly populated
+    when the value of a field is empty"""
+    conn = ControlConnection()
+    cmd = GetChanges()
+
+    assert conn.send(cmd) == b"*CHANGES?\n"
+
+    assert conn.receive_bytes(b"!Field 1=\n.\n") == b""
+
+    assert get_responses(conn) == [
+        (
+            cmd,
+            Changes(
+                values={"Field 1": ""},
+                no_value=[],
+                in_error=[],
+                multiline_values={},
+            ),
+        )
+    ]
+
+
+def test_get_changes_no_value():
+    """Test that the `no_value` field returned from `GetChanges` is correctly
+    populated"""
+    conn = ControlConnection()
+    cmd = GetChanges()
+
+    assert conn.send(cmd) == b"*CHANGES?\n"
+
+    assert conn.receive_bytes(b"!Field 1<\n!Field2<\n.\n") == b""
+
+    assert get_responses(conn) == [
+        (
+            cmd,
+            Changes(
+                values={},
+                no_value=["Field 1", "Field2"],
+                in_error=[],
+                multiline_values={},
+            ),
+        )
+    ]
+
+
+def test_get_changes_error():
+    """Test that the `error` field returned from `GetChanges` is correctly populated"""
+    conn = ControlConnection()
+    cmd = GetChanges()
+
+    assert conn.send(cmd) == b"*CHANGES?\n"
+
+    assert conn.receive_bytes(b"!Field1 (error)\n!Field2 (error)\n.\n") == b""
+
+    assert get_responses(conn) == [
+        (
+            cmd,
+            Changes(
+                values={},
+                no_value=[],
+                in_error=["Field1", "Field2"],
+                multiline_values={},
+            ),
+        )
+    ]
+
+
+def test_get_changes_multiline():
+    """Test that the `multiline_values` field returned from `GetChanges` is correctly
+    populated"""
+    conn = ControlConnection()
+    cmd = GetChanges(ChangeGroup.ALL, True)
+
+    assert conn.send(cmd) == b"*CHANGES?\n"
+
+    assert conn.receive_bytes(b"!Field1<\n.\n") == b"Field1?\n"
+
+    assert get_responses(conn, b"!Val1\n!Val2\n.\n") == [
+        (
+            cmd,
+            Changes(
+                values={},
+                no_value=[],
+                in_error=[],
+                multiline_values={"Field1": ["Val1", "Val2"]},
+            ),
+        )
+    ]
+
+
+def test_get_changes_multiline_no_values():
+    """Test that the `multiline_values` field returned from `GetChanges` is correctly
+    populated when the table in question has no values"""
+    conn = ControlConnection()
+    cmd = GetChanges(ChangeGroup.ALL, True)
+
+    assert conn.send(cmd) == b"*CHANGES?\n"
+
+    assert conn.receive_bytes(b"!Field1<\n.\n") == b"Field1?\n"
+
+    assert get_responses(conn, b".\n") == [
+        (
+            cmd,
+            Changes(
+                values={},
+                no_value=[],
+                in_error=[],
+                multiline_values={"Field1": []},
+            ),
+        )
+    ]
+
+
+def test_get_changes_multiline_no_multiline_fields():
+    """Test retrieving multiline fields when none are defined returns expected empty
+    multiline_values field."""
+    conn = ControlConnection()
+    cmd = GetChanges(ChangeGroup.ALL, True)
+
+    assert conn.send(cmd) == b"*CHANGES?\n"
+
+    assert conn.receive_bytes(b"!Field1=Value1\n.\n") == b""
+
+    assert get_responses(conn) == [
+        (
+            cmd,
+            Changes(
+                values={"Field1": "Value1"},
+                no_value=[],
+                in_error=[],
+                multiline_values={},
+            ),
+        )
+    ]
 
 
 def test_save():


### PR DESCRIPTION
Now we can retrieve almost all attributes for all fields - a few are ignored, like RAW, which we will never need.

These extra types are needed for the future PandABlocks-ioc repo, which will need to make use of them to create records.