### PR TITLE
Raise exceptions when server disconnects

### DIFF
--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -5,6 +5,11 @@ import pytest
 from pandablocks.asyncio import AsyncioClient
 from pandablocks.commands import CommandException, Get, Put
 
+from .conftest import DummyServer
+
+# Timeout in seconds
+TIMEOUT = 3
+
 
 @pytest.mark.asyncio
 async def test_asyncio_get(dummy_server_async):
@@ -35,3 +40,39 @@ async def test_asyncio_data(dummy_server_async, fast_dump, fast_dump_expected):
             if len(events) == 9:
                 break
     assert fast_dump_expected == events
+
+
+@pytest.mark.asyncio
+async def test_asyncio_connects(dummy_server_async: DummyServer):
+    async with AsyncioClient("localhost") as client:
+        assert client.is_connected()
+
+    assert not client.is_connected()
+
+
+@pytest.mark.asyncio
+async def test_asyncio_client_uncontactable():
+    """Test that a client raises an exception when the remote end is not
+    contactable"""
+    client = AsyncioClient("localhost")
+    with pytest.raises(OSError):
+        await client.connect()
+
+
+@pytest.mark.asyncio
+async def test_asyncio_client_fails_when_cannot_drain(dummy_server_async: DummyServer):
+    """Test that we don't hang indefinitely when failing to drain data from the OS
+    send buffer"""
+
+    # Note this value is probably OS-dependant. I found it experimentally.
+    large_data = b"ABC" * 100000000
+
+    client = AsyncioClient("localhost")
+    await client.connect()
+    await dummy_server_async.close()
+    with pytest.raises(asyncio.TimeoutError):
+        await client._ctrl_stream.write_and_drain(large_data, timeout=TIMEOUT)
+
+    # Can't use client.close() as it gets endlessly stuck. Do the important part.
+    assert client._ctrl_task
+    client._ctrl_task.cancel()


### PR DESCRIPTION
Now if you try and send data, either the write or the read can time out if you provide an optional timeout value