### PR TITLE
Fix delayed data frame updates

### DIFF
--- a/docs/explanations/performance.rst
+++ b/docs/explanations/performance.rst
@@ -51,7 +51,7 @@ Scale the data on the client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `AsyncioClient.data` and `BlockingClient.data` accept a ``scaled`` argument.
-Setting this to True will transfer the raw unscaled data, allowing for up to
+Setting this to False will transfer the raw unscaled data, allowing for up to
 50% more data to be sent depending on the datatype of the field. You can
 use the `StartData.fields` information to scale the data on the client.
 The `write_hdf_files` function uses this approach.
@@ -98,4 +98,17 @@ When panda-webcontrol was not installed, the following results were achieved:
 - PandA CPU usage about 65% (of both cores)
 - local client CPU usage about 60% (of a single core)
 
-Increasing above these throughputs failed most scans with DATA_OVERRUN.
+Increasing above these throughputs failed most scans with `DATA_OVERRUN`.
+
+Data overruns
+-------------
+
+If there is a `DATA_OVERRUN`, the server will stop sending data. The most recently
+received `FrameData` from either `AsyncioClient.data` or `BlockingClient.data` may
+be corrupt. This is the case if the ``scaled`` argument is set to False. The mechanism
+the server uses to send raw unscaled data is only able to detect the corrupt frame after
+it has already been sent. Conversely, the mechanism used to send scaled data aborts prior
+to sending a corrupt frame.
+
+The `write_hdf_files` function uses ``scaled=False``, so your HDF file may include some
+corrupt data in the event of an overrun.

--- a/pandablocks/responses.py
+++ b/pandablocks/responses.py
@@ -200,7 +200,9 @@ class EndReason(Enum):
     DISARMED = "Disarmed"
     #: Client disconnect detected
     EARLY_DISCONNECT = "Early disconnect"
-    #: Client not taking data quickly or network congestion, internal buffer overflow
+    #: Client not taking data quickly or network congestion, internal buffer overflow.
+    #: In raw unscaled mode (i.e., no server-side scaling), the most recent
+    #: `FrameData` is likely corrupted.
     DATA_OVERRUN = "Data overrun"
     #: Triggers too fast for configured data capture
     FRAMING_ERROR = "Framing error"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import pytest
 from click.testing import CliRunner
 
 from pandablocks import cli
+from pandablocks.hdf import HDFDataOverrunException
 from tests.conftest import STATE_RESPONSES, STATE_SAVEFILE, DummyServer
 
 
@@ -31,18 +32,7 @@ def test_writing_fast_hdf(dummy_server_in_thread: DummyServer, raw_dump, tmp_pat
         "PCAP.TS_START.Value",
     ]
     assert dummy_server_in_thread.received == ["*PCAP.ARM="]
-
-    def multiples(num, offset=0):
-        return pytest.approx(np.arange(1, 10001) * num + offset)
-
-    assert hdf_file["/COUNTER1.OUT.Max"][:] == multiples(1)
-    assert hdf_file["/COUNTER1.OUT.Mean"][:] == multiples(1)
-    assert hdf_file["/COUNTER1.OUT.Min"][:] == multiples(1)
-    assert hdf_file["/COUNTER2.OUT.Mean"][:] == multiples(2)
-    assert hdf_file["/COUNTER3.OUT.Value"][:] == multiples(3)
-    assert hdf_file["/PCAP.BITS2.Value"][:] == multiples(0)
-    assert hdf_file["/PCAP.SAMPLES.Value"][:] == multiples(0, offset=125)
-    assert hdf_file["/PCAP.TS_START.Value"][:] == multiples(2e-6, offset=7.2e-8 - 2e-6)
+    assert_all_data_in_hdf_file(hdf_file)
 
 
 def test_writing_overrun_hdf(
@@ -54,13 +44,16 @@ def test_writing_overrun_hdf(
     result = runner.invoke(
         cli.cli, ["hdf", "localhost", str(tmp_path / "%d.h5"), "--arm"]
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
+    assert isinstance(result.exception, HDFDataOverrunException)
     hdf_file = h5py.File(tmp_path / "1.h5", "r")
+    assert_all_data_in_hdf_file(hdf_file)
 
+
+def assert_all_data_in_hdf_file(hdf_file):
     def multiples(num, offset=0):
-        return pytest.approx(np.arange(1, 8936) * num + offset)
+        return pytest.approx(np.arange(1, 10001) * num + offset)
 
-    # Check we didn't write the last chunk
     assert hdf_file["/COUNTER1.OUT.Max"][:] == multiples(1)
     assert hdf_file["/COUNTER1.OUT.Mean"][:] == multiples(1)
     assert hdf_file["/COUNTER1.OUT.Min"][:] == multiples(1)


### PR DESCRIPTION
During data streaming, the "pending" stage is removed, so that clients gets `FrameData` as soon as possible. A disadvantage is that the client may receive some corrupt data. The user is able to detect this condition, so the benefit is thought to outweigh the disadvantage.

API changes:
-  Writing HDF5 files via `write_hdf_files`, an exception will now be raised if there's an overrun.
- The command line tool `pandablocks hdf` will have exit code 1 (instead of 0) if there's an overrun.

Documentation and tests updated accordingly.

Closes #54