### PR TITLE
Fix bug flushing Data frames from asyncio client

### DIFF
--- a/pandablocks/asyncio.py
+++ b/pandablocks/asyncio.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from asyncio.streams import StreamReader, StreamWriter
+from contextlib import suppress
 from typing import AsyncGenerator, Dict, Iterable, Optional
 
 from .commands import Command, T
@@ -179,3 +180,5 @@ class AsyncioClient:
         finally:
             fut.cancel()
             await stream.close()
+            with suppress(asyncio.CancelledError):
+                await fut


### PR DESCRIPTION
When AsyncioClient.data() was called with non-zero flush_period then it only yielded the Data after flush when a new packet of data appeared on the wire or at the end of acquisition. This changes it to be more eager and yield as soon as it is flushed.