### PR TITLE
Made conversion on enum fields to List[str] optional

### DIFF
--- a/pandablocks/utils.py
+++ b/pandablocks/utils.py
@@ -64,7 +64,7 @@ def words_to_table(
             assert field_info.labels, f"Enum field {field_name} has no labels"
             packing_value = [field_info.labels[x] for x in value]
         else:
-            packing_value = value.astype(np.uint32)
+            packing_value = value
 
         unpacked.update({field_name: packing_value})
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -209,6 +209,33 @@ def table_1_np_arrays() -> OrderedDict[str, Union[List, np.ndarray]]:
 
 
 @pytest.fixture
+def table_1_np_arrays_int_enums() -> OrderedDict[str, Union[List, np.ndarray]]:
+    # Intentionally not in panda order. Whatever types the np arrays are,
+    # the outputs from words_to_table will be uint32 or int32.
+    return OrderedDict(
+        {
+            "POSITION": np.array([-5, 678, 0], dtype=np.int32),
+            "TIME1": np.array([100, 0, 9], dtype=np.uint32),
+            "OUTA1": np.array([0, 1, 1], dtype=np.uint8),
+            "OUTB1": np.array([0, 0, 1], dtype=np.uint8),
+            "OUTD1": np.array([1, 0, 1], dtype=np.uint8),
+            "OUTE1": np.array([0, 0, 1], dtype=np.uint8),
+            "OUTC1": np.array([0, 0, 1], dtype=np.uint8),
+            "OUTF1": np.array([1, 0, 1], dtype=np.uint8),
+            "TIME2": np.array([0, 55, 9999], dtype=np.uint32),
+            "OUTA2": np.array([0, 0, 1], dtype=np.uint8),
+            "OUTB2": np.array([0, 0, 1], dtype=np.uint8),
+            "REPEATS": np.array([5, 0, 50000], dtype=np.uint32),
+            "OUTC2": np.array([1, 1, 1], dtype=np.uint8),
+            "OUTD2": np.array([0, 0, 1], dtype=np.uint8),
+            "OUTE2": np.array([0, 0, 1], dtype=np.uint8),
+            "OUTF2": np.array([1, 0, 1], dtype=np.uint8),
+            "TRIGGER": np.array([0, 6, 0], dtype=np.uint8),
+        }
+    )
+
+
+@pytest.fixture
 def table_1_not_in_panda_order() -> OrderedDict[str, Union[List, np.ndarray]]:
     return OrderedDict(
         {
@@ -348,6 +375,20 @@ def test_table_packing_unpack(
     actual: UnpackedArray
     for field_name, actual in output_table.items():
         expected = table_1_np_arrays[str(field_name)]
+        np.testing.assert_array_equal(actual, expected)
+
+
+def test_table_packing_unpack_no_convert_enum(
+    table_1_np_arrays_int_enums: OrderedDict[str, np.ndarray],
+    table_field_info: TableFieldInfo,
+    table_data_1: List[str],
+):
+    assert table_field_info.row_words
+    output_table = words_to_table(table_data_1, table_field_info)
+
+    actual: UnpackedArray
+    for field_name, actual in output_table.items():
+        expected = table_1_np_arrays_int_enums[str(field_name)]
         np.testing.assert_array_equal(actual, expected)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, OrderedDict, Union
+from typing import Dict, List, OrderedDict
 
 import numpy as np
 import pytest
@@ -157,36 +157,13 @@ def table_field_info(table_fields) -> TableFieldInfo:
 
 
 @pytest.fixture
-def table_1() -> OrderedDict[str, Union[List, np.ndarray]]:
-    return OrderedDict(
-        {
-            "REPEATS": [5, 0, 50000],
-            "TRIGGER": ["Immediate", "BITC=1", "Immediate"],
-            "POSITION": [-5, 678, 0],
-            "TIME1": [100, 0, 9],
-            "OUTA1": [0, 1, 1],
-            "OUTB1": [0, 0, 1],
-            "OUTC1": [0, 0, 1],
-            "OUTD1": [1, 0, 1],
-            "OUTE1": [0, 0, 1],
-            "OUTF1": [1, 0, 1],
-            "TIME2": [0, 55, 9999],
-            "OUTA2": [0, 0, 1],
-            "OUTB2": [0, 0, 1],
-            "OUTC2": [1, 1, 1],
-            "OUTD2": [0, 0, 1],
-            "OUTE2": [0, 0, 1],
-            "OUTF2": [1, 0, 1],
-        }
-    )
-
-
-@pytest.fixture
-def table_1_np_arrays() -> OrderedDict[str, Union[List, np.ndarray]]:
+def table_1_np_arrays() -> OrderedDict[str, UnpackedArray]:
     # Intentionally not in panda order. Whatever types the np arrays are,
     # the outputs from words_to_table will be uint32 or int32.
     return OrderedDict(
         {
+            "REPEATS": np.array([5, 0, 50000], dtype=np.uint32),
+            "TRIGGER": ["Immediate", "BITC=1", "Immediate"],
             "POSITION": np.array([-5, 678, 0], dtype=np.int32),
             "TIME1": np.array([100, 0, 9], dtype=np.uint32),
             "OUTA1": np.array([0, 1, 1], dtype=np.uint8),
@@ -198,18 +175,16 @@ def table_1_np_arrays() -> OrderedDict[str, Union[List, np.ndarray]]:
             "TIME2": np.array([0, 55, 9999], dtype=np.uint32),
             "OUTA2": np.array([0, 0, 1], dtype=np.uint8),
             "OUTB2": np.array([0, 0, 1], dtype=np.uint8),
-            "REPEATS": np.array([5, 0, 50000], dtype=np.uint32),
             "OUTC2": np.array([1, 1, 1], dtype=np.uint8),
             "OUTD2": np.array([0, 0, 1], dtype=np.uint8),
             "OUTE2": np.array([0, 0, 1], dtype=np.uint8),
             "OUTF2": np.array([1, 0, 1], dtype=np.uint8),
-            "TRIGGER": np.array(["Immediate", "BITC=1", "Immediate"], dtype="<U9"),
         }
     )
 
 
 @pytest.fixture
-def table_1_np_arrays_int_enums() -> OrderedDict[str, Union[List, np.ndarray]]:
+def table_1_np_arrays_int_enums() -> OrderedDict[str, UnpackedArray]:
     # Intentionally not in panda order. Whatever types the np arrays are,
     # the outputs from words_to_table will be uint32 or int32.
     return OrderedDict(
@@ -236,31 +211,6 @@ def table_1_np_arrays_int_enums() -> OrderedDict[str, Union[List, np.ndarray]]:
 
 
 @pytest.fixture
-def table_1_not_in_panda_order() -> OrderedDict[str, Union[List, np.ndarray]]:
-    return OrderedDict(
-        {
-            "REPEATS": [5, 0, 50000],
-            "TRIGGER": ["Immediate", "BITC=1", "Immediate"],
-            "POSITION": [-5, 678, 0],
-            "TIME1": [100, 0, 9],
-            "OUTA1": [0, 1, 1],
-            "OUTB1": [0, 0, 1],
-            "OUTC1": [0, 0, 1],
-            "OUTD1": [1, 0, 1],
-            "OUTF1": [1, 0, 1],
-            "OUTE1": [0, 0, 1],
-            "TIME2": [0, 55, 9999],
-            "OUTA2": [0, 0, 1],
-            "OUTC2": [1, 1, 1],
-            "OUTB2": [0, 0, 1],
-            "OUTD2": [0, 0, 1],
-            "OUTE2": [0, 0, 1],
-            "OUTF2": [1, 0, 1],
-        }
-    )
-
-
-@pytest.fixture
 def table_data_1() -> List[str]:
     return [
         "2457862149",
@@ -279,19 +229,19 @@ def table_data_1() -> List[str]:
 
 
 @pytest.fixture
-def table_2() -> Dict[str, Union[List, np.ndarray]]:
-    table: Dict[str, Union[List, np.ndarray]] = dict(
-        REPEATS=[1, 0],
+def table_2_np_arrays() -> Dict[str, UnpackedArray]:
+    table: Dict[str, UnpackedArray] = dict(
+        REPEATS=np.array([1, 0], dtype=np.uint32),
         TRIGGER=["Immediate", "Immediate"],
-        POSITION=[-20, 2**31 - 1],
-        TIME1=[12, 2**32 - 1],
-        TIME2=[32, 1],
+        POSITION=np.array([-20, 2**31 - 1], dtype=np.int32),
+        TIME1=np.array([12, 2**32 - 1], dtype=np.uint32),
+        TIME2=np.array([32, 1], dtype=np.uint32),
     )
 
-    table["OUTA1"] = [False, True]
-    table["OUTA2"] = [True, False]
+    table["OUTA1"] = np.array([0, 1], dtype=np.uint8)
+    table["OUTA2"] = np.array([1, 0], dtype=np.uint8)
     for key in "BCDEF":
-        table[f"OUT{key}1"] = table[f"OUT{key}2"] = [False, False]
+        table[f"OUT{key}1"] = table[f"OUT{key}2"] = np.array([0, 0], dtype=np.uint8)
 
     return table
 
@@ -311,7 +261,7 @@ def table_data_2() -> List[str]:
 
 
 def test_table_packing_pack_length_mismatched(
-    table_1: OrderedDict[str, Union[List, np.ndarray]],
+    table_1_np_arrays: OrderedDict[str, UnpackedArray],
     table_field_info: TableFieldInfo,
 ):
     assert table_field_info.row_words
@@ -319,17 +269,16 @@ def test_table_packing_pack_length_mismatched(
     # Adjust one of the record lengths so it mismatches
     field_info = table_field_info.fields[("OUTC1")]
     assert field_info
-    table_1["OUTC1"] = np.array([1, 2, 3, 4, 5, 6, 7, 8])
+    table_1_np_arrays["OUTC1"] = np.array([1, 2, 3, 4, 5, 6, 7, 8])
 
     with pytest.raises(AssertionError):
-        table_to_words(table_1, table_field_info)
+        table_to_words(table_1_np_arrays, table_field_info)
 
 
 @pytest.mark.parametrize(
     "table_fixture_name,table_data_fixture_name",
     [
-        ("table_1_not_in_panda_order", "table_data_1"),
-        ("table_2", "table_data_2"),
+        ("table_2_np_arrays", "table_data_2"),
         ("table_1_np_arrays", "table_data_1"),
     ],
 )
@@ -339,9 +288,7 @@ def test_table_to_words_and_words_to_table(
     table_field_info: TableFieldInfo,
     request,
 ):
-    table: Dict[str, Union[List, np.ndarray]] = request.getfixturevalue(
-        table_fixture_name
-    )
+    table: Dict[str, UnpackedArray] = request.getfixturevalue(table_fixture_name)
     table_data: List[str] = request.getfixturevalue(table_data_fixture_name)
 
     output_data = table_to_words(table, table_field_info)
@@ -379,7 +326,7 @@ def test_table_packing_unpack(
 
 
 def test_table_packing_unpack_no_convert_enum(
-    table_1_np_arrays_int_enums: OrderedDict[str, np.ndarray],
+    table_1_np_arrays_int_enums: OrderedDict[str, UnpackedArray],
     table_field_info: TableFieldInfo,
     table_data_1: List[str],
 ):
@@ -393,12 +340,12 @@ def test_table_packing_unpack_no_convert_enum(
 
 
 def test_table_packing_pack(
-    table_1: Dict[str, Union[List, np.ndarray]],
+    table_1_np_arrays: Dict[str, UnpackedArray],
     table_field_info: TableFieldInfo,
     table_data_1: List[str],
 ):
     assert table_field_info.row_words
-    unpacked = table_to_words(table_1, table_field_info)
+    unpacked = table_to_words(table_1_np_arrays, table_field_info)
 
     for actual, expected in zip(unpacked, table_data_1):
         assert actual == expected


### PR DESCRIPTION
By default pandablocks-ioc will refer to enum values by their integer indices, with values being stored in a `numpy.uint8`.

Because of this, we make conversion to a `List[str]` of enum values optional in pandablocks client.