### PR TITLE
Added an optional frameswritten setter

### DIFF
--- a/src/pandablocks/asyncio.py
+++ b/src/pandablocks/asyncio.py
@@ -72,7 +72,7 @@ class AsyncioClient:
 
     async def connect(self):
         """Connect to the control port, and be ready to handle commands"""
-        await self._ctrl_stream.connect(self._host, 8888),
+        await self._ctrl_stream.connect(self._host, 8888)
 
         self._ctrl_task = asyncio.create_task(
             self._ctrl_read_forever(self._ctrl_stream.reader)

--- a/src/pandablocks/responses.py
+++ b/src/pandablocks/responses.py
@@ -196,8 +196,6 @@ class EndReason(Enum):
 
     #: Experiment completed by falling edge of ``PCAP.ENABLE```
     OK = "Ok"
-    #: Experiment manually completed by ``*PCAP.DISARM=`` command
-    DISARMED = "Disarmed"
     #: Client disconnect detected
     EARLY_DISCONNECT = "Early disconnect"
     #: Client not taking data quickly or network congestion, internal buffer overflow.
@@ -210,12 +208,15 @@ class EndReason(Enum):
     DRIVER_DATA_OVERRUN = "Driver data overrun"
     #: Data capture too fast for memory bandwidth
     DMA_DATA_ERROR = "DMA data error"
-
     # Reasons below this point are not from the server, they are generated in code
     #: An unknown exception occurred during HDF5 file processing
     UNKNOWN_EXCEPTION = "Unknown exception"
     #: StartData packets did not match when trying to continue printing to a file
     START_DATA_MISMATCH = "Start Data mismatched"
+    #: Experiment manually completed by ``DATA:CAPTURE``
+    MANUALLY_STOPPED = "Manually stopped"
+    #: Experiment manually completed by ``*PCAP.DISARM=`` command
+    DISARMED = "Disarmed"
 
 
 @dataclass

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -1,0 +1,61 @@
+import queue
+from pathlib import Path
+
+import numpy as np
+
+from pandablocks.hdf import (
+    Pipeline,
+    create_default_pipeline,
+    stop_pipeline,
+)
+from pandablocks.responses import EndData, EndReason, FieldCapture, FrameData, StartData
+
+
+def test_pipeline_returns_number_written(tmp_path):
+    NUMBER_OF_FRAMES_WRITTEN = 10000
+
+    num_written_queue = queue.Queue()
+
+    class DummyDownstream(Pipeline):
+        def __init__(self):
+            self.what_to_do = {int: num_written_queue.put_nowait}
+            super().__init__()
+
+    file_counter = DummyDownstream()
+
+    try:
+        pipeline = create_default_pipeline(
+            iter([Path(tmp_path / "1.h5")]), file_counter
+        )
+
+        pipeline[0].queue.put_nowait(
+            StartData(
+                [
+                    FieldCapture(
+                        name="COUNTER1.OUT",
+                        type=np.dtype("float64"),
+                        capture="Value",
+                        scale=1,
+                        offset=0,
+                        units="",
+                    )
+                ],
+                0,
+                "Scaled",
+                "Framed",
+                52,
+            ),
+        )
+        pipeline[0].queue.put_nowait(
+            FrameData(
+                np.array(
+                    NUMBER_OF_FRAMES_WRITTEN * [(1,)],
+                    dtype=[("COUNTER1.OUT.Value", "<f8")],
+                )
+            )
+        )
+        pipeline[0].queue.put_nowait(EndData(5, EndReason.DISARMED))
+
+        assert num_written_queue.get() == NUMBER_OF_FRAMES_WRITTEN
+    finally:
+        stop_pipeline(pipeline)


### PR DESCRIPTION
Added an optional setter in the HDF5 writer to set a record detailing the number of frames written.

We require merging and release of this PR before the ioc side: https://github.com/PandABlocks/PandABlocks-ioc/pull/83

According to https://github.com/dls-controls/pythonSoftIOC/issues/142, the set of a record should be thread safe, but we should do some testing before we release.