### PR TITLE
adjusted code to allow the server to send either  name

### DIFF
--- a/src/pandablocks/commands.py
+++ b/src/pandablocks/commands.py
@@ -92,31 +92,36 @@ class CommandException(Exception):
 # zip() because typing does not support variadic type variables.  See
 # typeshed PR #1550 for discussion.
 @overload
-def _execute_commands(c1: Command[T]) -> ExchangeGenerator[Tuple[T]]: ...
+def _execute_commands(c1: Command[T]) -> ExchangeGenerator[Tuple[T]]:
+    ...
 
 
 @overload
 def _execute_commands(
     c1: Command[T], c2: Command[T2]
-) -> ExchangeGenerator[Tuple[T, T2]]: ...
+) -> ExchangeGenerator[Tuple[T, T2]]:
+    ...
 
 
 @overload
 def _execute_commands(
     c1: Command[T], c2: Command[T2], c3: Command[T3]
-) -> ExchangeGenerator[Tuple[T, T2, T3]]: ...
+) -> ExchangeGenerator[Tuple[T, T2, T3]]:
+    ...
 
 
 @overload
 def _execute_commands(
     c1: Command[T], c2: Command[T2], c3: Command[T3], c4: Command[T4]
-) -> ExchangeGenerator[Tuple[T, T2, T3, T4]]: ...
+) -> ExchangeGenerator[Tuple[T, T2, T3, T4]]:
+    ...
 
 
 @overload
 def _execute_commands(
     *commands: Command[Any],
-) -> ExchangeGenerator[Tuple[Any, ...]]: ...
+) -> ExchangeGenerator[Tuple[Any, ...]]:
+    ...
 
 
 def _execute_commands(*commands):

--- a/src/pandablocks/connections.py
+++ b/src/pandablocks/connections.py
@@ -28,7 +28,10 @@ __all__ = [
     "DataConnection",
 ]
 
-# The name of the samples field used for averaging unscaled fields
+# The names of the samples field used for averaging unscaled fields
+# In newer versions it's GATE_DURATION but we keep SAMPLES for backwards
+# compatibility
+GATE_DURATION_FIELD = "PCAP.GATE_DURATION.Value"
 SAMPLES_FIELD = "PCAP.SAMPLES.Value"
 
 


### PR DESCRIPTION
Allowed the client to take either `PCAP.SAMPLES` or `PCAP.GATE_DURATION` from the server.