### PR TITLE
made ruff compliant

### DIFF
--- a/src/pandablocks/commands.py
+++ b/src/pandablocks/commands.py
@@ -92,36 +92,31 @@ class CommandException(Exception):
 # zip() because typing does not support variadic type variables.  See
 # typeshed PR #1550 for discussion.
 @overload
-def _execute_commands(c1: Command[T]) -> ExchangeGenerator[Tuple[T]]:
-    ...
+def _execute_commands(c1: Command[T]) -> ExchangeGenerator[Tuple[T]]: ...
 
 
 @overload
 def _execute_commands(
     c1: Command[T], c2: Command[T2]
-) -> ExchangeGenerator[Tuple[T, T2]]:
-    ...
+) -> ExchangeGenerator[Tuple[T, T2]]: ...
 
 
 @overload
 def _execute_commands(
     c1: Command[T], c2: Command[T2], c3: Command[T3]
-) -> ExchangeGenerator[Tuple[T, T2, T3]]:
-    ...
+) -> ExchangeGenerator[Tuple[T, T2, T3]]: ...
 
 
 @overload
 def _execute_commands(
     c1: Command[T], c2: Command[T2], c3: Command[T3], c4: Command[T4]
-) -> ExchangeGenerator[Tuple[T, T2, T3, T4]]:
-    ...
+) -> ExchangeGenerator[Tuple[T, T2, T3, T4]]: ...
 
 
 @overload
 def _execute_commands(
     *commands: Command[Any],
-) -> ExchangeGenerator[Tuple[Any, ...]]:
-    ...
+) -> ExchangeGenerator[Tuple[Any, ...]]: ...
 
 
 def _execute_commands(*commands):


### PR DESCRIPTION
Because of git strangeness (probably cherry-picks) we have to apply this change again, as https://github.com/PandABlocks/PandABlocks-client/pull/84/commits/188aa10993f05de899ee7d3fc249257bcd6208ab didn't apply.