### PR TITLE
Make BlockingClient send thread safe

### DIFF
--- a/src/pandablocks/blocking.py
+++ b/src/pandablocks/blocking.py
@@ -103,7 +103,7 @@ class BlockingClient:
                 to_send = self._ctrl_connection.receive_bytes(received)
                 s.sendall(to_send)
                 for command, response in self._ctrl_connection.responses():
-                    assert cr[id(command)] is ..., "Already got response for {command}"
+                    assert cr[id(command)] is ..., f"Already got response for {command}"
                     cr[id(command)] = response
         responses = list(cr.values())
         for response in responses:


### PR DESCRIPTION
At MAX IV we use the `BlockingClient` in several sardana controllers.
The same client is used in different methods to send commands. Sardana automatically runs some of those methods in a separate threads. We sometimes get an exception raised from the `pandablocks` library:

```
Dummy-38       WARNING  2025-01-21 14:35:45,549 pandabox_ctrl: pandabox_ctrl.StopOne(1) has failed
Traceback (most recent call last):
  File "/opt/conda/envs/sardana/lib/python3.11/site-packages/sardana_finest/ctrl/FinestPandaBoxTGCtrl.py", line 47, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/sardana/lib/python3.11/site-packages/sardana_finest/ctrl/FinestPandaBoxTGCtrl.py", line 207, in AbortOne
    self.pandabox.send(Put("BITS2.A", "0"))
  File "/opt/conda/envs/sardana/lib/python3.11/site-packages/pandablocks/blocking.py", line 103, in send
    assert cr[id(command)] is ..., "Already got response for {command}"
           ~~^^^^^^^^^^^^^
KeyError: 139893205968464
```

In this case we got a response from a command that was sent from a different thread.

We can fix that by setting a lock in our code but it would be much nicer to fix it in the library.

I added a lock in the send method to make it thread safe.

I also fixed in this MR a typo: `f` was missing for the ` "Already got response for {command}"` f-string.