### PR TITLE
Update installation command for HDF5 support

### DIFF
--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -30,7 +30,7 @@ $ python3 -m pip install pandablocks
 If you need to write HDF files you should install the hdf5 extra:
 
 ```
-$ python3 -m pip install pandablocks[hdf5]
+$ python3 -m pip install pandablocks[h5py]
 ```
 
 If you require a feature that is not currently released you can also install


### PR DESCRIPTION
pip install now throws "WARNING: pandablocks 0.10.4 does not provide the extra 'hdf5'". It should be python3 -m pip install pandablocks[h5py]